### PR TITLE
Declaration ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 Breaking changes:
 
 New features:
+- Declarations are now guaranteed to be rendered in the input order.
 
 Bugfixes:
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -5,12 +5,6 @@ Caveats
 
 Shorthand syntax is generally avoided, in part because its complex structure is often difficult to represent at the type level, and also because [it might be an anti-pattern](https://csswizardry.com/2016/12/css-shorthand-syntax-considered-an-anti-pattern/).
 
-## Declaration ordering
-
-Because declarations are modeled as records, the order in which they appear in PureScript code may differ from the rendered output.
-
-Navigating this pitfall is as simple as ensuring that declarations are written such that ordering does not matter. For example, shorthand "overrides" (such as overriding a `margin` declaration with `margin-left`) within a single ruleset should be avoided. If needed, a simple workaround is to split the ruleset into two, since ruleset ordering _is_ preserved.
-
 ## Vendor prefixes
 
 You may want to consider applying [Autoprefixer](https://github.com/postcss/autoprefixer) to the CSS output to improve your style sheet's compatibility with older browsers.

--- a/examples/output/ZenGarments.css
+++ b/examples/output/ZenGarments.css
@@ -6,35 +6,35 @@ html {
   font-size: 62.5%;
 }
 body {
+  font-family: "Helvetica", "Arial", sans-serif;
+  color: hsl(0.0, 0.0%, 20.0%);
   background-color: hsl(210.0, 21.05%, 92.55%);
   background-image: url("i/denim2.png");
-  background-position: 50% 350px;
   background-repeat: no-repeat;
-  color: hsl(0.0, 0.0%, 20.0%);
-  font-family: "Helvetica", "Arial", sans-serif;
+  background-position: 50% 350px;
 }
 h1 {
   font-family: "Helvetica", "Arial", sans-serif;
-  font-size: 4.2rem;
   font-weight: bold;
+  font-size: 4.2rem;
   margin-bottom: 0.5em;
 }
 h2 {
   font-family: "Helvetica", "Arial", sans-serif;
-  font-size: 1.8rem;
   font-weight: bold;
+  font-size: 1.8rem;
   margin-bottom: 1em;
 }
 h3 {
   font-family: "Helvetica", "Arial", sans-serif;
-  font-size: 1.5rem;
   font-weight: bold;
+  font-size: 1.5rem;
   margin-bottom: 1em;
 }
 h4, h5, h6 {
   font-family: "Helvetica", "Arial", sans-serif;
-  font-size: 1.2rem;
   font-weight: bold;
+  font-size: 1.2rem;
 }
 *.wf-active body, *.wf-active h1, *.wf-active h2, *.wf-active h3, *.wf-active h4, *.wf-active h5, *.wf-active h6 {
   font-family: "effra", sans-serif;
@@ -59,10 +59,10 @@ input.empty::placeholder, textarea.empty::placeholder {
   color: hsl(0.0, 100.0%, 50.0%);
 }
 td {
-  border-top-color: hsl(0.0, 0.0%, 66.67%);
-  border-top-style: solid;
-  border-top-width: 1px;
   padding: 0.25em 1em;
+  border-top-width: 1px;
+  border-top-style: solid;
+  border-top-color: hsl(0.0, 0.0%, 66.67%);
 }
 em {
   font-style: italic;
@@ -75,37 +75,37 @@ mark {
   font-style: normal;
 }
 video {
-  height: auto;
   width: 100%;
+  height: auto;
 }
 a {
+  text-decoration-line: none;
   color: hsl(37.0, 33.0%, 48.0%);
   position: relative;
-  text-decoration-line: none;
-  transition-duration: 0.25s;
   transition-property: all;
+  transition-duration: 0.25s;
   transition-timing-function: linear;
 }
 a::after {
-  background-color: hsl(37.0, 33.0%, 48.0%);
-  bottom: -0.2em;
   content: "";
   display: block;
+  background-color: hsl(37.0, 33.0%, 48.0%);
   height: 2px;
+  width: 100%;
+  position: absolute;
+  bottom: -0.2em;
   left: 0;
   opacity: 0;
-  position: absolute;
-  transition-duration: 0.25s;
   transition-property: all;
   transition-timing-function: linear;
-  width: 100%;
+  transition-duration: 0.25s;
 }
 a:hover, a:focus {
   color: hsl(0.0, 0.0%, 0.0%);
 }
 a:hover::after, a:focus::after {
-  bottom: 0;
   opacity: 1;
+  bottom: 0;
 }
 img {
   display: block;
@@ -122,16 +122,16 @@ b {
   font-weight: normal;
 }
 abbr, abbr[title], acronym {
-  border-style: none;
   font-size: 75%;
   letter-spacing: 0.2em;
   text-transform: uppercase;
+  border-style: none;
 }
 code {
-  color: hsl(0.0, 0.0%, 60.0%);
-  font-family: "Consolas", "Courier New", "Courier", monospace;
   font-size: 1.4rem;
   line-height: 1;
+  font-family: "Consolas", "Courier New", "Courier", monospace;
+  color: hsl(0.0, 0.0%, 60.0%);
 }
 sub, sup {
   line-height: 0;
@@ -141,26 +141,26 @@ sub, sup {
   color: hsl(0.0, 0.0%, 20.0%);
 }
 *.phark {
-  background-color: transparent;
-  background-position: 0 0;
-  background-repeat: no-repeat;
   display: block;
   text-indent: -9999px;
+  background-position: 0 0;
+  background-repeat: no-repeat;
+  background-color: transparent;
 }
 *.phark-link {
   overflow: hidden;
 }
 *.clearfix::after {
-  clear: both;
   content: ".";
   display: block;
   height: 0;
+  clear: both;
   visibility: hidden;
 }
 *.offscreen {
-  display: block;
-  left: -9999px;
   position: absolute;
+  left: -9999px;
+  display: block;
 }
 *.onscreen {
   left: 0;
@@ -182,27 +182,27 @@ sub, sup {
 }
 *.kellum {
   display: block;
-  overflow: hidden;
   text-indent: 100%;
   white-space: nowrap;
+  overflow: hidden;
 }
 *.page-wrapper {
-  margin: 0 auto;
   width: 90%;
+  margin: 0 auto;
 }
 *.main h3, *.preamble h3, *.select {
-  color: hsl(224.0, 40.0%, 25.0%);
-  font-size: 2rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
   visibility: hidden;
+  font-size: 2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: hsl(224.0, 40.0%, 25.0%);
 }
 *.wf-active *.main h3, *.wf-active *.preamble h3 {
   font-weight: 900;
 }
 *.main h3::after, *.preamble h3::after, *.select::after {
-  display: block;
   visibility: visible;
+  display: block;
 }
 *.main p, *.preamble p {
   font-size: 2rem;
@@ -217,56 +217,56 @@ sub, sup {
   opacity: 0;
 }
 *[role="banner"] h1 {
-  color: hsl(216.0, 53.0%, 20.0%);
-  font-size: 3.5rem;
-  font-weight: 900;
-  letter-spacing: 0.1em;
   padding: 1em 0 0;
   text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 3.5rem;
+  font-weight: 900;
+  color: hsl(216.0, 53.0%, 20.0%);
   visibility: hidden;
 }
 *[role="banner"] h1::before {
   content: "CSS Zen Garments";
-  display: block;
   visibility: visible;
+  display: block;
 }
 *[role="banner"] h1::after {
-  color: hsla(216.0, 53.4%, 20.2%, 0.4);
   content: "Made Locally";
+  visibility: visible;
   display: block;
+  letter-spacing: 0.5em;
   font-size: 1.4rem;
   font-weight: normal;
-  letter-spacing: 0.5em;
   margin: 0.5em 0 3em;
-  visibility: visible;
+  color: hsla(216.0, 53.4%, 20.2%, 0.4);
 }
 *[role="banner"] h2 {
-  color: hsla(216.13, 53.14%, 34.31%, 0.5);
-  display: none;
-  font-weight: 400;
-  text-transform: uppercase;
   visibility: hidden;
+  display: none;
+  text-transform: uppercase;
+  font-weight: 400;
+  color: hsla(216.13, 53.14%, 34.31%, 0.5);
 }
 *[role="banner"] h2::after {
   content: "Impeccable Quality";
-  display: block;
   visibility: visible;
+  display: block;
 }
 *.summary p {
-  font-size: 1.8rem;
-  letter-spacing: 0.1em;
-  line-height: 1.6;
   text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 1.8rem;
+  line-height: 1.6;
 }
 *.preamble {
   background-color: transparent;
   background-image: url("i/sep.png");
-  background-position: 50% 0;
   background-repeat: no-repeat;
+  background-position: 50% 0;
 }
 *.preamble h3::after {
-  content: "A Fashion-Forward Future";
   visibility: visible;
+  content: "A Fashion-Forward Future";
 }
 *.explanation h3::after {
   content: "See Yourself in a Different Way";
@@ -286,36 +286,36 @@ sub, sup {
 }
 *.design-selection ul {
   list-style-type: none;
-  margin: 0 auto;
   width: 94%;
+  margin: 0 auto;
 }
 *.design-selection ul::after {
-  clear: both;
   content: ".";
   display: block;
   height: 0;
+  clear: both;
   visibility: hidden;
 }
 *.design-selection li {
-  color: hsl(0.0, 0.0%, 66.67%);
   float: left;
+  width: 50%;
   font-size: 1.2rem;
   margin: 0 0 1em;
-  width: 50%;
+  color: hsl(0.0, 0.0%, 66.67%);
 }
 *.design-selection li:nth-child(odd) {
-  clear: left;
-  padding-right: 3%;
   width: 47%;
+  padding-right: 3%;
+  clear: left;
 }
 *.design-name {
   display: block;
   font-size: 1.4rem;
   font-weight: bold;
-  letter-spacing: 0.1em;
   margin: 0 0 0.24em;
-  position: relative;
   text-transform: uppercase;
+  letter-spacing: 0.1em;
+  position: relative;
 }
 *.design-name::after {
   background-image: none;
@@ -331,28 +331,28 @@ sub, sup {
   height: 1px;
 }
 *.select::after {
-  background-color: transparent;
-  background-image: url("i/waves.png");
-  background-position: 50% 0;
-  background-repeat: no-repeat;
-  color: hsl(216.0, 53.0%, 20.0%);
   content: "Washes & Styles";
   font-size: 1.8rem;
-  margin: 0 auto 2em;
-  padding: 2em 0 0;
   text-align: center;
-  visibility: visible;
   width: 7em;
+  margin: 0 auto 2em;
+  background-color: transparent;
+  background-image: url("i/waves.png");
+  background-repeat: no-repeat;
+  background-position: 50% 0;
+  padding: 2em 0 0;
+  color: hsl(216.0, 53.0%, 20.0%);
+  visibility: visible;
 }
 *.archives, *.resources {
-  left: -9999px;
   position: absolute;
+  left: -9999px;
 }
 *.design-archives ul {
   list-style-type: none;
   margin: 1em 0 0;
-  text-align: center;
   width: 100%;
+  text-align: center;
 }
 *.design-archives li {
   display: inline-block;
@@ -360,9 +360,9 @@ sub, sup {
 }
 *.design-archives a {
   display: block;
-  overflow: hidden;
   text-indent: 100%;
   white-space: nowrap;
+  overflow: hidden;
 }
 *.next {
   margin-right: 3em;
@@ -370,10 +370,10 @@ sub, sup {
 *.next a {
   background-color: transparent;
   background-image: url("s/czg.svg");
-  background-position: 10px -56px;
   background-repeat: no-repeat;
-  height: 37px;
+  background-position: 10px -56px;
   width: 43px;
+  height: 37px;
 }
 *.next a:hover, *.next a:focus {
   background-position: 10px -138px;
@@ -384,10 +384,10 @@ sub, sup {
 *.previous a {
   background-color: transparent;
   background-image: url("s/czg.svg");
-  background-position: 10px -220px;
   background-repeat: no-repeat;
-  height: 37px;
+  background-position: 10px -220px;
   width: 43px;
+  height: 37px;
 }
 *.previous a:hover, *.previous a:focus {
   background-position: 10px -302px;
@@ -398,10 +398,10 @@ sub, sup {
 *.viewall a {
   background-color: transparent;
   background-image: url("s/czg.svg");
-  background-position: -56px -55px;
   background-repeat: no-repeat;
-  height: 39px;
+  background-position: -56px -55px;
   width: 39px;
+  height: 39px;
 }
 *.viewall a:hover, *.viewall a:focus {
   background-position: -56px -137px;
@@ -421,32 +421,32 @@ footer a:first-child {
   text-align: center;
 }
 *.zen-resources ul::before {
-  background-color: hsl(205.71, 9.09%, 84.9%);
   content: "";
-  display: block;
   height: 4px;
-  margin: 0 auto 2em;
-  text-align: center;
   width: 80px;
+  background-color: hsl(205.71, 9.09%, 84.9%);
+  display: block;
+  text-align: center;
+  margin: 0 auto 2em;
 }
 *.zen-resources li {
-  display: inline-block;
   margin: 0 0 1em 3em;
+  display: inline-block;
 }
 *.zen-resources li:first-child {
   margin-left: 0;
 }
 *.zen-resources a {
-  background-color: transparent;
-  background-image: url("s/czg.svg");
-  background-position: 0 0;
-  background-repeat: no-repeat;
   display: inline-block;
-  height: 60px;
-  overflow: hidden;
   text-indent: 100%;
   white-space: nowrap;
+  overflow: hidden;
+  background-color: transparent;
+  background-image: url("s/czg.svg");
+  background-repeat: no-repeat;
+  background-position: 0 0;
   width: 60px;
+  height: 60px;
 }
 *.view-css a {
   background-position: -502px 12px;
@@ -484,39 +484,39 @@ footer a:first-child {
     background-position: 90% 80%;
   }
   *.intro::before {
-    background-color: transparent;
-    background-image: url("s/czg.svg");
-    background-position: -184px -99px;
-    background-repeat: no-repeat;
     content: "";
     display: block;
+    width: 105px;
     height: 30px;
-    left: 3%;
     position: fixed;
     top: 154px;
-    width: 105px;
+    left: 3%;
+    background-color: transparent;
+    background-image: url("s/czg.svg");
+    background-repeat: no-repeat;
+    background-position: -184px -99px;
   }
   *[role="article"], *[role="banner"], footer {
     padding: 0 30% 10em 10%;
-    position: relative;
     text-align: right;
+    position: relative;
   }
   *[role="article"] h3, *[role="banner"] h2 {
-    font-size: 1.5rem;
-    left: 75%;
-    letter-spacing: 0;
     position: absolute;
-    text-align: left;
     top: -0.75em;
+    left: 75%;
     width: 10em;
+    text-align: left;
+    font-size: 1.5rem;
+    letter-spacing: 0;
   }
   *[role="article"] h3::after {
     position: absolute;
     top: 0;
   }
   *[role="banner"] {
-    padding-bottom: 3em;
     padding-top: 200px;
+    padding-bottom: 3em;
   }
   *[role="banner"] h1 {
     font-size: 4.8rem;
@@ -525,91 +525,91 @@ footer a:first-child {
   }
   *[role="banner"] h1::after {
     position: absolute;
-    right: 30%;
     top: 15.7em;
+    right: 30%;
   }
   *[role="banner"] h2 {
     display: block;
-    font-size: 1.9rem;
-    left: 75.5%;
-    line-height: 1;
     top: 8.1em;
     width: 3em;
+    left: 75.5%;
+    font-size: 1.9rem;
+    line-height: 1;
   }
   *[role="banner"] h2::before {
-    bottom: 0;
-    color: hsla(0.0, 0.0%, 0.0%, 0.15);
+    visibility: visible;
     content: "Est. 2003";
     display: block;
-    font-size: 50rem;
-    font-weight: 900;
-    height: 2em;
-    left: -0.5em;
-    line-height: 1;
-    margin: auto;
-    mask-image: url("i/denim-mask2.png");
     position: fixed;
-    right: 0;
     top: -0.1em;
-    transform: rotate(-90deg);
-    visibility: visible;
+    bottom: 0;
+    left: -0.5em;
+    right: 0;
+    margin: auto;
+    font-weight: 900;
+    font-size: 50rem;
+    color: hsla(0.0, 0.0%, 0.0%, 0.15);
     width: 100%;
+    height: 2em;
+    line-height: 1;
+    transform: rotate(-90deg);
+    mask-image: url("i/denim-mask2.png");
   }
   *.summary p:nth-child(2) {
     background-color: hsl(60.0, 100.0%, 50.0%);
-    font-size: 1.4rem;
     position: relative;
-    top: 2em;
     visibility: hidden;
+    top: 2em;
+    font-size: 1.4rem;
   }
   *.summary p:nth-child(2)::before {
-    background-color: transparent;
-    background-image: url("s/czg.svg");
-    background-position: -159px -1px;
-    background-repeat: no-repeat;
     content: "";
     display: block;
-    height: 30px;
+    visibility: visible;
     position: absolute;
     right: 21em;
     top: -0.25em;
-    visibility: visible;
-    width: 6em;
-  }
-  *.summary p:nth-child(2)::after {
     background-color: transparent;
     background-image: url("s/czg.svg");
-    background-position: -277px 0;
     background-repeat: no-repeat;
+    background-position: -159px -1px;
+    width: 6em;
+    height: 30px;
+  }
+  *.summary p:nth-child(2)::after {
     content: "";
     display: block;
-    height: 30px;
+    visibility: visible;
     position: absolute;
     right: 14em;
     top: -0.25em;
-    visibility: visible;
-    width: 6em;
-  }
-  *.summary p:nth-child(2) a {
     background-color: transparent;
     background-image: url("s/czg.svg");
-    background-position: -376px -93px;
     background-repeat: no-repeat;
-    display: block;
-    height: 25px;
-    overflow: hidden;
-    position: absolute;
-    right: 7em;
-    text-indent: 100%;
-    top: 0;
-    visibility: visible;
-    white-space: nowrap;
+    background-position: -277px 0;
     width: 6em;
+    height: 30px;
+  }
+  *.summary p:nth-child(2) a {
+    visibility: visible;
+    background-color: transparent;
+    background-image: url("s/czg.svg");
+    background-repeat: no-repeat;
+    background-position: -376px -93px;
+    width: 6em;
+    height: 25px;
+    text-indent: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 7em;
   }
   *.summary p:nth-child(2) a:hover, *.summary p:nth-child(2) a:focus {
-    background-image: none;
     background-position: -396px -3px;
     text-indent: 0;
+    background-image: none;
   }
   *.summary p:nth-child(2) a[href*="css"] {
     background-position: -472px -94px;
@@ -625,25 +625,25 @@ footer a:first-child {
     top: 5.9em;
   }
   *.design-selection li {
+    width: 23%;
     margin-bottom: 3em;
     padding-right: 2%;
-    width: 23%;
   }
   *.design-selection li:nth-child(odd) {
+    width: 23%;
     clear: none;
     padding-right: 2%;
-    width: 23%;
   }
   *.next {
-    margin-left: -0.4em;
     margin-right: 2em;
+    margin-left: -0.4em;
   }
   *.viewall {
     margin-left: 0;
   }
   footer {
-    margin-top: -5em;
     padding-bottom: 3em;
+    margin-top: -5em;
   }
 }
 @media screen and (min-width: 1130px) {
@@ -651,8 +651,8 @@ footer a:first-child {
     padding-left: 25%;
   }
   *.design-selection {
-    left: 5%;
     position: absolute;
+    left: 5%;
     top: 30em;
   }
   *.design-selection ul {
@@ -664,18 +664,18 @@ footer a:first-child {
     margin-bottom: 2em;
   }
   *.design-selection.design-selection.design-selection li {
-    padding: 0;
     width: 100%;
+    padding: 0;
   }
   *.select::after {
-    background-position: 0 bottom;
-    margin: 0 0 2em;
-    padding: 0 0 2em;
     text-align: left;
+    background-position: 0 bottom;
+    padding: 0 0 2em;
+    margin: 0 0 2em;
   }
   *.design-archives {
-    left: 5%;
     position: absolute;
+    left: 5%;
     top: 95em;
   }
 }
@@ -693,26 +693,26 @@ footer a:first-child {
   }
 }
 *.intro {
-  animation-duration: 1s;
-  animation-iteration-count: 1;
   animation-name: FADEY;
+  animation-duration: 1s;
   animation-timing-function: ease-in-out;
+  animation-iteration-count: 1;
 }
 *[role="article"] {
-  animation-delay: 0.5s;
+  opacity: 0;
+  animation-name: FADEY;
   animation-duration: 1s;
+  animation-timing-function: ease-in-out;
+  animation-delay: 0.5s;
   animation-fill-mode: forwards;
   animation-iteration-count: 1;
-  animation-name: FADEY;
-  animation-timing-function: ease-in-out;
-  opacity: 0;
 }
 *.design-selection, *.design-archives {
-  animation-delay: 1s;
+  opacity: 0;
+  animation-name: FADEY;
   animation-duration: 1s;
+  animation-timing-function: ease-in-out;
+  animation-delay: 1s;
   animation-fill-mode: forwards;
   animation-iteration-count: 1;
-  animation-name: FADEY;
-  animation-timing-function: ease-in-out;
-  opacity: 0;
 }

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -1,15 +1,14 @@
-module Tecton.Internal (class AlignContentKeyword, class AlignItemsKeyword, class AlignSelfKeyword, class AlignmentBaselineKeyword, class AlignmentBaselineOrBaselineShiftKeyword, class AllPropertiesAnimatable, class AngleTag, class Animatable, class AnimationDirectionKeyword, class AnimationFillModeKeyword, class AnimationPlayStateKeyword, class AttachmentKeyword, class Attribute, class BaselineShiftKeyword, class BaselineSourceKeyword, class BoxKeyword, class BuildFromScratch, class ByAtt, class Calc, class ClearKeyword, class CollectDeclarations, class CollectFontFaceDeclarations, class CollectMediaFeatures, class Combine, class ContentKeyword, class CounterStyleKeyword, class Declaration, class DirectionKeyword, class DisplayKeyword, class DominantBaselineKeyword, class Element, class ExtentKeyword, class FlexDirectionKeyword, class FlexWrapKeyword, class FloatKeyword, class FontFaceDeclaration, class FontFaceFontStyleKeyword, class FontFaceFontWeightKeyword, class FontFormatKeyword, class FontSizeKeyword, class FontStretchKeyword, class FontStyleKeyword, class FontWeightKeyword, class GenericFontFamilyKeyword, class IsAnimationNameList, class IsAttachmentList, class IsAttribute, class IsBaselineShift, class IsBgImageList, class IsBgSize, class IsBgSizeList, class IsBorderColor, class IsBorderRadius, class IsBorderStyle, class IsBorderWidth, class IsBoxList, class IsColor, class IsColorStopListHead, class IsColorStopListTail, class IsExtensibleSelector, class IsFontFaceFontStyle, class IsFontFaceFontWeight, class IsFontFaceSrcList, class IsFontFamilyList, class IsFontSize, class IsFontStretch, class IsFontStyle, class IsFontWeight, class IsImage, class IsInset, class IsInsetBlock, class IsLetterSpacing, class IsLineHeight, class IsLineWidth, class IsList, class IsListStyleImage, class IsListStyleType, class IsMargin, class IsMaskReferenceList, class IsMaxWidth, class IsMinWidth, class IsOverflow, class IsPadding, class IsPerspective, class IsPosition, class IsPositionList, class IsPositionX, class IsPositionY, class IsRadialGradientDimensions, class IsRepeatStyle, class IsRepeatStyleList, class IsSelector, class IsSelectorList, class IsShadow, class IsSingleAnimationDirectionList, class IsSingleAnimationFillModeList, class IsSingleAnimationIterationCountList, class IsSingleAnimationPlayStateList, class IsSingleBorderRadius, class IsSingleMargin, class IsSingleTransitionPropertyList, class IsTextDecorationLine, class IsTextShadow, class IsTextShadowList, class IsTextTransform, class IsTimeList, class IsTop, class IsTransformList, class IsTransformOrigin, class IsVerticalAlign, class IsWidth, class IsWordSpacing, class JustifyContentKeyword, class LengthPercentageTag, class LengthTag, class LineStyleKeyword, class LineWidthKeyword, class ListStylePositionKeyword, class MaxWidthKeyword, class MediaFeature, class MediaTypeKeyword, class MinWidthKeyword, class MkStatement, class MultiVal, class OutlineLineStyleKeyword, class OverflowKeyword, class PercentageTag, class PositionKeyword, class Property, class Pseudo, class Pseudo', class PseudoPrefix, class Render, class RepeatStyle1dKeyword, class RepeatStyle2dKeyword, class SelectorStatus, class ShapeKeyword, class StepPosition, class TextAlignKeyword, class TextDecorationStyleKeyword, class TextOverflowKeyword, class TextTransformCapitalizationKeyword, class TimeTag, class ToNumber, class ToVal, class VisibilityKeyword, class WhiteSpaceKeyword, class WidthKeyword, Add, Angle, AttributePredicate, CSSColor, CommonKeyword, Configuration, CustomAttribute, Divide, EasingFunction, Extensible, FitContent, FontFace, FontFaceFormatFunction, Gradient, Inextensible, KeyframeBlock, Keyframes, KeyframesName, Length, LengthPercentage, LocalFunction, Measure, MediaQuery, Multiply, NestedRule, Nil, Nth, Orientation, Pair(..), Percentage, PseudoClass, PseudoElement, Ratio(..), Repeating, Resolution, Selector, Statement, Subtract, Time, TransformFunction, URL, Val, a, abbr, absolute, accept, acceptCharset, accesskey, acronym, action, active, add, adjacentSibling, after, alignContent, alignItems, alignSelf, alignmentBaseline, all, alphabetic, alt, alternate, alternateReverse, animationDelay, animationDirection, animationDuration, animationFillMode, animationIterationCount, animationName, animationPlayState, animationTimingFunction, arabicIndic, armenian, article, aside, async, att, attContains, attElemWhitespace, attEndsWith, attEq, attStartsWith, attStartsWithHyphen, audio, auto, autocomplete, autofocus, autoplay, b, backgroundAttachment, backgroundClip, backgroundColor, backgroundImage, backgroundOrigin, backgroundPosition, backgroundRepeat, backgroundSize, backwards, baseline, baselineShift, baselineSource, before, bengali, blink, block, blockquote, body, bold, bolder, borderBottomColor, borderBottomLeftRadius, borderBottomRightRadius, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderLeftColor, borderLeftStyle, borderLeftWidth, borderRadius, borderRightColor, borderRightStyle, borderRightWidth, borderStyle, borderTopColor, borderTopLeftRadius, borderTopRightRadius, borderTopStyle, borderTopWidth, borderWidth, both, bottom, boxShadow, breakSpaces, buildFromScratch, button, byAtt, byClass, byId, byPseudo, cambodian, canvas, capitalize, caption, center, central, ch, charset, checked, child, circle, cite, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, class', clear, clip, closestCorner, closestSide, cm, code, col, colgroup, collapse, collectDeclarations, collectFontFaceDeclarations, collectMediaFeatures, collection, color, cols, colspan, column, columnGap, columnReverse, combine, compact, condensed, contain, content, contentBox, contenteditable, contents, controls, coords, cover, cubicBezier, currentColor, cursive, dashed, data', datetime, dd, decimal, decimalLeadingZero, default, defer, deg, descendant, details, devanagari, dir, direction, dirname, disabled, disc, disclosureClosed, disclosureOpen, display, div, divide, dl, dominantBaseline, dotted, double, download, dpcm, dpi, draggable, dt, ease, easeIn, easeInOut, easeOut, ellipse, ellipsis, em, em', embeddedOpentype, emoji, empty, enabled, enctype, end, even, ex, expanded, extraCondensed, extraExpanded, fangsong, fantasy, farthestCorner, farthestSide, fdval, fieldset, first, firstChild, firstLetter, firstLine, firstOfType, fitContent, fixed, flex, flexBasis, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, float, flowRoot, focus, fontFace, fontFamily, fontSize, fontSizeAdjust, fontStretch, fontStyle, fontWeight, footer, for, form, formaction, format, forwards, fullSizeKana, fullWidth, gap, generalSibling, georgian, grid, groove, gujarati, gurmukhi, h1, h2, h3, h4, h5, h6, hanging, header, headers, hebrew, height, hidden, high, hiragana, hiraganaIroha, hover, hr, href, hreflang, html, httpEquiv, i, id, ideographic, img, inch, indeterminate, infinite, inherit, initial, inline, inlineBlock, inlineFlex, inlineGrid, inlineTable, input, inset, insetBlock, insetBlockEnd, insetBlockStart, insetInline, insetInlineEnd, insetInlineStart, inside, invert, ismap, italic, jumpBoth, jumpEnd, jumpNone, jumpStart, justify, justifyAll, justifyContent, kannada, katakana, katakanaIroha, keyframes, keyframesName, khmer, kind, label, landscape, lang, lang', lao, large, larger, last, lastChild, lastOfType, left, legend, letterSpacing, li, lighter, line, lineHeight, lineThrough, linear, linearGradient, link, list, listItem, listStyleImage, listStylePosition, listStyleType, local, local', loop, low, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, lowercase, ltr, main', malayalam, mapVal, margin, marginBottom, marginLeft, marginRight, marginTop, mark, marker, maskImage, matchParent, math, mathematical, matrix, matrix3d, max, maxContent, maxHeight, maxWidth, maxlength, media, media', medium, menu, method, middle, min, minContent, minHeight, minWidth, mkStatement, mm, mongolian, monospace, ms, multiVal, multiValImpl, multiple, multiply, multiplyFlipped, muted, myanmar, name, nav, nil, noRepeat, none, normal, not, novalidate, nowrap, nth, nthChild, nthLastChild, nthOfType, number, oblique, odd, ol, onabort, onafterprint, onbeforeprint, onbeforeunload, onblur, oncanplay, oncanplaythrough, onchange, onclick, oncontextmenu, oncopy, oncuechange, oncut, ondblclick, ondrag, ondragend, ondragenter, ondragleave, ondragover, ondragstart, ondrop, ondurationchange, onemptied, onended, onerror, onfocus, onhashchange, oninput, oninvalid, onkeydown, onkeypress, onkeyup, onload, onloadeddata, onloadedmetadata, onloadstart, onlyChild, onlyOfType, onmousedown, onmousemove, onmouseout, onmouseover, onmouseup, onmousewheel, onoffline, ononline, onpagehide, onpageshow, onpaste, onpause, onplay, onplaying, onpopstate, onprogress, onratechange, onreset, onresize, onscroll, onsearch, onseeked, onseeking, onselect, onstalled, onstorage, onsubmit, onsuspend, ontimeupdate, ontoggle, onunload, onvolumechange, onwaiting, onwheel, opacity, open, opentype, optgroup, optimum, option, order, oriya, outlineColor, outlineOffset, outlineStyle, outlineWidth, outset, outside, overflow, overflowX, overflowY, overline, p, padding, paddingBottom, paddingBox, paddingLeft, paddingRight, paddingTop, path, pattern, paused, pc, pct, persian, perspective, placeholder, polygon, polyline, portrait, position, poster, pre, preLine, preWrap, preload, pretty, print, progress, pseudoPrefix, pt, pval, px, q, rad, radialGradient, readonly, rect, rel, relative, rem, render, renderInline, renderSheet, repeat', repeatX, repeatY, repeating, required, reverse, reversed, ridge, right, role, root, rotate, rotate3d, rotateX, rotateY, rotateZ, round, row, rowGap, rowReverse, rows, rowspan, rtl, running, sandbox, sansSerif, scale, scale3d, scaleX, scaleY, scaleZ, scope, screen, scroll, sec, section, select, selected, selection, semiCondensed, semiExpanded, serif, shape, size, sizes, skewX, skewY, small, smaller, solid, space, spaceAround, spaceBetween, span, spellcheck, square, src, srcdoc, srclang, srcset, start, static, step, stepEnd, stepStart, steps, sticky, stretch, strong, style, sub, subtract, summary, sup, super, svg, systemUI, tabindex, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup, tamil, target, tbody, td, telugu, textAlign, textBottom, textDecorationColor, textDecorationLine, textDecorationStyle, textIndent, textOverflow, textShadow, textTop, textTransform, textarea, tfoot, th, thai, thead, thick, thin, tibetan, time, title, top, tr, transform, transformOrigin, transitionDelay, transitionDuration, transitionProperty, transitionTimingFunction, translate, translate', translate3d, translateX, translateY, translateZ, transparent, truetype, turn, type', uiMonospace, uiRounded, uiSansSerif, uiSerif, ul, ultraCondensed, ultraExpanded, underline, universal, unset, upperAlpha, upperArmenian, upperLatin, upperRoman, uppercase, url, usemap, val, value, verticalAlign, vh, video, visibility, visible, visited, vmax, vmin, vw, wavy, whiteSpace, width, woff, woff2, wordSpacing, wrap, wrapReverse, xLarge, xSmall, xxLarge, xxSmall, zIndex, ($=), (&#), (&.), (&:), (&@), (*=), (*@), (:/), (:=), (?), (@*), (@+@), (@-@), (@/), (@=), (^=), (|*), (|+), (|=), (|>), (|~), (~), (~=)) where
+module Tecton.Internal (class AlignContentKeyword, class AlignItemsKeyword, class AlignSelfKeyword, class AlignmentBaselineKeyword, class AlignmentBaselineOrBaselineShiftKeyword, class AllPropertiesAnimatable, class AngleTag, class Animatable, class AnimationDirectionKeyword, class AnimationFillModeKeyword, class AnimationPlayStateKeyword, class Assoc, class AttachmentKeyword, class Attribute, class BaselineShiftKeyword, class BaselineSourceKeyword, class BoxKeyword, class ByAtt, class Calc, class ClearKeyword, class CollectMediaFeatures, class Combine, class ContentKeyword, class CounterStyleKeyword, class Declaration, class DirectionKeyword, class DisplayKeyword, class DominantBaselineKeyword, class Elem, class Element, class ExtentKeyword, class FlexDirectionKeyword, class FlexWrapKeyword, class FloatKeyword, class FontFaceDeclaration, class FontFaceFontStyleKeyword, class FontFaceFontWeightKeyword, class FontFormatKeyword, class FontSizeKeyword, class FontStretchKeyword, class FontStyleKeyword, class FontWeightKeyword, class GenericFontFamilyKeyword, class IsAnimationNameList, class IsAttachmentList, class IsAttribute, class IsBaselineShift, class IsBgImageList, class IsBgSize, class IsBgSizeList, class IsBorderColor, class IsBorderRadius, class IsBorderStyle, class IsBorderWidth, class IsBoxList, class IsColor, class IsColorStopListHead, class IsColorStopListTail, class IsExtensibleSelector, class IsFontFaceFontStyle, class IsFontFaceFontWeight, class IsFontFaceSrcList, class IsFontFamilyList, class IsFontSize, class IsFontStretch, class IsFontStyle, class IsFontWeight, class IsImage, class IsInset, class IsInsetBlock, class IsLetterSpacing, class IsLineHeight, class IsLineWidth, class IsList, class IsListStyleImage, class IsListStyleType, class IsMargin, class IsMaskReferenceList, class IsMaxWidth, class IsMinWidth, class IsOverflow, class IsPadding, class IsPerspective, class IsPosition, class IsPositionList, class IsPositionX, class IsPositionY, class IsRadialGradientDimensions, class IsRepeatStyle, class IsRepeatStyleList, class IsSelector, class IsSelectorList, class IsShadow, class IsSingleAnimationDirectionList, class IsSingleAnimationFillModeList, class IsSingleAnimationIterationCountList, class IsSingleAnimationPlayStateList, class IsSingleBorderRadius, class IsSingleMargin, class IsSingleTransitionPropertyList, class IsTextDecorationLine, class IsTextShadow, class IsTextShadowList, class IsTextTransform, class IsTimeList, class IsTop, class IsTransformList, class IsTransformOrigin, class IsVerticalAlign, class IsWidth, class IsWordSpacing, class JustifyContentKeyword, class LengthPercentageTag, class LengthTag, class LineStyleKeyword, class LineWidthKeyword, class ListStylePositionKeyword, class MaxWidthKeyword, class MediaFeature, class MediaTypeKeyword, class MinWidthKeyword, class MkStatement, class MultiVal, class OutlineLineStyleKeyword, class OverflowKeyword, class PercentageTag, class PositionKeyword, class Property, class Pseudo, class Pseudo', class PseudoPrefix, class RepeatStyle1dKeyword, class RepeatStyle2dKeyword, class SelectorStatus, class ShapeKeyword, class StepPosition, class TextAlignKeyword, class TextDecorationStyleKeyword, class TextOverflowKeyword, class TextTransformCapitalizationKeyword, class TimeTag, class ToNumber, class ToVal, class VisibilityKeyword, class WhiteSpaceKeyword, class WidthKeyword, Add, Angle, AttributePredicate, CSSColor, CommonKeyword, Configuration, CustomAttribute, Declaration', Divide, EasingFunction, Extensible, FitContent, FontFace, FontFaceDeclaration', FontFaceFormatFunction, Gradient, Inextensible, KeyframeBlock, Keyframes, KeyframesName, Length, LengthPercentage, LocalFunction, Measure, MediaQuery, Multiply, NestedRule, Nil, Nth, Orientation, Pair(..), Percentage, PseudoClass, PseudoElement, Ratio(..), Repeating, Resolution, Selector, Statement, Subtract, Time, TransformFunction, URL, Val, a, abbr, absolute, accept, acceptCharset, accesskey, acronym, action, active, add, adjacentSibling, after, alignContent, alignItems, alignSelf, alignmentBaseline, all, alphabetic, alt, alternate, alternateReverse, animationDelay, animationDirection, animationDuration, animationFillMode, animationIterationCount, animationName, animationPlayState, animationTimingFunction, arabicIndic, armenian, article, aside, assoc, async, att, attContains, attElemWhitespace, attEndsWith, attEq, attStartsWith, attStartsWithHyphen, audio, auto, autocomplete, autofocus, autoplay, b, backgroundAttachment, backgroundClip, backgroundColor, backgroundImage, backgroundOrigin, backgroundPosition, backgroundRepeat, backgroundSize, backwards, baseline, baselineShift, baselineSource, before, bengali, blink, block, blockquote, body, bold, bolder, borderBottomColor, borderBottomLeftRadius, borderBottomRightRadius, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderLeftColor, borderLeftStyle, borderLeftWidth, borderRadius, borderRightColor, borderRightStyle, borderRightWidth, borderStyle, borderTopColor, borderTopLeftRadius, borderTopRightRadius, borderTopStyle, borderTopWidth, borderWidth, both, bottom, boxShadow, breakSpaces, button, byAtt, byClass, byId, byPseudo, cambodian, canvas, capitalize, caption, center, central, ch, charset, checked, child, circle, cite, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, class', clear, clip, closestCorner, closestSide, cm, code, col, colgroup, collapse, collectMediaFeatures, collection, color, cols, colspan, column, columnGap, columnReverse, combine, compact, condensed, contain, content, contentBox, contenteditable, contents, controls, coords, cover, cubicBezier, currentColor, cursive, dashed, data', datetime, dd, decimal, decimalLeadingZero, default, defer, deg, descendant, details, devanagari, dir, direction, dirname, disabled, disc, disclosureClosed, disclosureOpen, display, div, divide, dl, dominantBaseline, dotted, double, download, dpcm, dpi, draggable, dt, ease, easeIn, easeInOut, easeOut, ellipse, ellipsis, em, em', embeddedOpentype, emoji, empty, enabled, enctype, end, even, ex, expanded, extraCondensed, extraExpanded, fangsong, fantasy, farthestCorner, farthestSide, fdval, fieldset, first, firstChild, firstLetter, firstLine, firstOfType, fitContent, fixed, flex, flexBasis, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, float, flowRoot, focus, fontFace, fontFamily, fontSize, fontSizeAdjust, fontStretch, fontStyle, fontWeight, footer, for, form, formaction, format, forwards, fullSizeKana, fullWidth, gap, generalSibling, georgian, grid, groove, gujarati, gurmukhi, h1, h2, h3, h4, h5, h6, hanging, header, headers, hebrew, height, hidden, high, hiragana, hiraganaIroha, hover, hr, href, hreflang, html, httpEquiv, i, id, ideographic, img, inch, indeterminate, infinite, inherit, initial, inline, inlineBlock, inlineFlex, inlineGrid, inlineTable, input, inset, insetBlock, insetBlockEnd, insetBlockStart, insetInline, insetInlineEnd, insetInlineStart, inside, invert, ismap, italic, jumpBoth, jumpEnd, jumpNone, jumpStart, justify, justifyAll, justifyContent, kannada, katakana, katakanaIroha, keyframes, keyframesName, khmer, kind, label, landscape, lang, lang', lao, large, larger, last, lastChild, lastOfType, left, legend, letterSpacing, li, lighter, line, lineHeight, lineThrough, linear, linearGradient, link, list, listItem, listStyleImage, listStylePosition, listStyleType, local, local', loop, low, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, lowercase, ltr, main', malayalam, mapVal, margin, marginBottom, marginLeft, marginRight, marginTop, mark, marker, maskImage, matchParent, math, mathematical, matrix, matrix3d, max, maxContent, maxHeight, maxWidth, maxlength, media, media', medium, menu, method, middle, min, minContent, minHeight, minWidth, mkStatement, mm, mongolian, monospace, ms, multiVal, multiValImpl, multiple, multiply, multiplyFlipped, muted, myanmar, name, nav, nil, noRepeat, none, normal, not, novalidate, nowrap, nth, nthChild, nthLastChild, nthOfType, number, oblique, odd, ol, onabort, onafterprint, onbeforeprint, onbeforeunload, onblur, oncanplay, oncanplaythrough, onchange, onclick, oncontextmenu, oncopy, oncuechange, oncut, ondblclick, ondrag, ondragend, ondragenter, ondragleave, ondragover, ondragstart, ondrop, ondurationchange, onemptied, onended, onerror, onfocus, onhashchange, oninput, oninvalid, onkeydown, onkeypress, onkeyup, onload, onloadeddata, onloadedmetadata, onloadstart, onlyChild, onlyOfType, onmousedown, onmousemove, onmouseout, onmouseover, onmouseup, onmousewheel, onoffline, ononline, onpagehide, onpageshow, onpaste, onpause, onplay, onplaying, onpopstate, onprogress, onratechange, onreset, onresize, onscroll, onsearch, onseeked, onseeking, onselect, onstalled, onstorage, onsubmit, onsuspend, ontimeupdate, ontoggle, onunload, onvolumechange, onwaiting, onwheel, opacity, open, opentype, optgroup, optimum, option, order, oriya, outlineColor, outlineOffset, outlineStyle, outlineWidth, outset, outside, overflow, overflowX, overflowY, overline, p, padding, paddingBottom, paddingBox, paddingLeft, paddingRight, paddingTop, path, pattern, paused, pc, pct, persian, perspective, placeholder, polygon, polyline, portrait, position, poster, pre, preLine, preWrap, preload, pretty, print, progress, pseudoPrefix, pt, pval, px, q, rad, radialGradient, readonly, rect, rel, relative, rem, renderInline, renderInline', renderSheet, repeat', repeatX, repeatY, repeating, required, reverse, reversed, ridge, right, role, root, rotate, rotate3d, rotateX, rotateY, rotateZ, round, row, rowGap, rowReverse, rows, rowspan, rtl, runVal, running, sandbox, sansSerif, scale, scale3d, scaleX, scaleY, scaleZ, scope, screen, scroll, sec, section, select, selected, selection, semiCondensed, semiExpanded, serif, shape, size, sizes, skewX, skewY, small, smaller, solid, space, spaceAround, spaceBetween, span, spellcheck, square, src, srcdoc, srclang, srcset, start, static, step, stepEnd, stepStart, steps, sticky, stretch, strong, style, sub, subtract, summary, sup, super, svg, systemUI, tabindex, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup, tamil, target, tbody, td, telugu, textAlign, textBottom, textDecorationColor, textDecorationLine, textDecorationStyle, textIndent, textOverflow, textShadow, textTop, textTransform, textarea, tfoot, th, thai, thead, thick, thin, tibetan, time, title, top, tr, transform, transformOrigin, transitionDelay, transitionDuration, transitionProperty, transitionTimingFunction, translate, translate', translate3d, translateX, translateY, translateZ, transparent, truetype, turn, type', uiMonospace, uiRounded, uiSansSerif, uiSerif, ul, ultraCondensed, ultraExpanded, underline, universal, unset, upperAlpha, upperArmenian, upperLatin, upperRoman, uppercase, url, usemap, val, value, verticalAlign, vh, video, visibility, visible, visited, vmax, vmin, vw, wavy, whiteSpace, width, woff, woff2, wordSpacing, wrap, wrapReverse, xLarge, xSmall, xxLarge, xxSmall, zIndex, ($=), (&#), (&.), (&:), (&@), (*=), (*@), (:/), (:=), (?), (@*), (@+@), (@-@), (@/), (@=), (^=), (|*), (|+), (|=), (|>), (|~), (~), (~=)) where
 
 import Prelude hiding (add, bottom, sub, top)
 
 import Color (Color, cssStringHSLA, toHexString)
 import Control.Monad.Writer (Writer, execWriter, tell)
-import Control.Semigroupoid (composeFlipped)
 import Data.Array (replicate)
 import Data.Array as Array
 import Data.Either as Either
 import Data.Foldable (foldl, foldr)
-import Data.FoldableWithIndex (class FoldableWithIndex, foldlWithIndex)
+import Data.FoldableWithIndex (foldlWithIndex)
 import Data.Int as Int
 import Data.List (List(..), (:))
 import Data.Number.Format as Number
@@ -25,8 +24,6 @@ import Prim.Row as Row
 import Prim.RowList (class RowToList, RowList)
 import Prim.RowList as RL
 import Record as Record
-import Record.Builder (Builder)
-import Record.Builder as RB
 import Type.Proxy (Proxy(..))
 
 --------------------------------------------------------------------------------
@@ -47,6 +44,12 @@ class IsList (x :: Type) (xs :: Type)
 
 instance IsList x xs => IsList x (x /\ xs)
 else instance IsList x x
+
+class Elem (x :: Type) (xs :: Type)
+
+instance Elem x (x /\ xs)
+else instance Elem x x
+else instance Elem x xs => Elem x (a /\ xs)
 
 --------------------------------------------------------------------------------
 
@@ -153,14 +156,8 @@ data Statement
   = NestedAtRule NestedRule (Array Statement)
   | Ruleset (Array Val) Val
 
-class MkStatement (a :: Type) (b :: Type) (c :: Type) | a -> c where
+class MkStatement (a :: Type) (b :: Type) (c :: Type) | a -> b, a -> c where
   mkStatement :: a -> b -> Writer (Array c) Unit
-
-class BuildFromScratch (a :: Row Type) (b :: Type) | b -> a where
-  buildFromScratch :: Builder (Record a) b -> b
-
-instance BuildFromScratch () (Record r) where
-  buildFromScratch builder = RB.build builder {}
 
 instance MkStatement MediaQuery (Writer (Array Statement) Unit) Statement where
   mkStatement mq nested =
@@ -170,17 +167,17 @@ instance MkStatement MediaQuery (Writer (Array Statement) Unit) Statement where
       $ execWriter nested
 
 else instance
-  ( RowToList r rl
-  , CollectFontFaceDeclarations rl r ("font-family" :: Unit, src :: Unit | provided)
-  , BuildFromScratch empty (Record r)
+  ( Elem (Proxy "font-family") descriptors
+  , Elem (Proxy "src") descriptors
   ) =>
-  MkStatement FontFace (Builder (Record empty) (Record r)) Statement where
+  MkStatement FontFace (Writer (List FontFaceDeclaration') descriptors) Statement where
   mkStatement _ decls =
     tell
       $ pure
       $ Ruleset [ val "@font-face" ]
       $ concatDeclarations
-      $ collectFontFaceDeclarations (Proxy :: _ rl) (buildFromScratch decls) Nil
+      $ map (\(FontFaceDeclaration' d) -> d)
+      $ execWriter decls
 
 else instance
   MkStatement Keyframes (Writer (Array KeyframeBlock) Unit) Statement where
@@ -190,50 +187,41 @@ else instance
       $ NestedAtRule (NestedRule $ val "keyframes " <> val kfname)
       $ ((\(KeyframeBlock sels decls) -> Ruleset sels decls) <$> execWriter blocks)
 
-else instance
-  ( RowToList r rl
-  , CollectDeclarations rl r
-  , AllPropertiesAnimatable rl
-  , BuildFromScratch empty (Record r)
-  ) =>
-  MkStatement (Measure Percentage) (Builder (Record empty) (Record r)) KeyframeBlock where
+else instance AllPropertiesAnimatable ps => MkStatement (Measure Percentage) (Writer (List Declaration') ps) KeyframeBlock where
   mkStatement sel decls =
     tell
       $ pure
       $ KeyframeBlock [ val sel ]
       $ concatDeclarations
-      $ collectDeclarations (Proxy :: _ rl) (buildFromScratch decls) Nil
+      $ map (\(Declaration' d) -> d)
+      $ execWriter decls
 
 else instance
-  ( RowToList r rl
-  , CollectDeclarations rl r
-  , AllPropertiesAnimatable rl
-  , BuildFromScratch empty (Record r)
+  ( AllPropertiesAnimatable ps
   , IsList (Measure Percentage) xs
   , MultiVal xs
   ) =>
-  MkStatement (Measure Percentage /\ xs) (Builder (Record empty) (Record r)) KeyframeBlock where
+  MkStatement (Measure Percentage /\ xs) (Writer (List Declaration') ps) KeyframeBlock where
   mkStatement sels decls =
     tell
       $ pure
       $ KeyframeBlock (multiVal sels)
       $ concatDeclarations
-      $ collectDeclarations (Proxy :: _ rl) (buildFromScratch decls) Nil
+      $ map (\(Declaration' d) -> d)
+      $ execWriter decls
 
 else instance
   ( IsSelectorList selectors
   , MultiVal selectors
-  , RowToList r rl
-  , CollectDeclarations rl r
-  , BuildFromScratch empty (Record r)
   ) =>
-  MkStatement selectors (Builder (Record empty) (Record r)) Statement where
+  MkStatement selectors (Writer (List Declaration') ps) Statement where
   mkStatement sel decls =
     tell
       $ pure
       $ Ruleset (multiVal sel)
       $ concatDeclarations
-      $ collectDeclarations (Proxy :: _ rl) (buildFromScratch decls) Nil
+      $ map (\(Declaration' d) -> d)
+      $ execWriter decls
 
 infixr 0 mkStatement as ?
 
@@ -241,134 +229,108 @@ infixr 0 mkStatement as ?
 
 -- Declarations
 
-infixr 0 RB.insert as :=
+newtype Declaration' = Declaration' (Val /\ Val)
 
-concatDeclarations :: forall f. FoldableWithIndex Int f => f (Val /\ Val) -> Val
+newtype FontFaceDeclaration' = FontFaceDeclaration' (Val /\ Val)
+
+class Assoc k v w where
+  assoc :: k -> v -> Writer (List w) k
+
+instance (IsSymbol p, Property p) => Assoc (Proxy p) CommonKeyword Declaration' where
+  assoc _ v =
+    let
+      prop = Proxy :: _ p
+    in
+      tell (pure $ Declaration' $ val prop /\ val v) *> pure prop
+else instance (IsSymbol p, Declaration p v) => Assoc (Proxy p) v Declaration' where
+  assoc _ v =
+    let
+      prop = Proxy :: _ p
+    in
+      tell (pure $ Declaration' $ val prop /\ pval prop v) *> pure prop
+
+instance
+  ( IsSymbol d
+  , FontFaceDeclaration d v
+  ) =>
+  Assoc (Proxy d) v FontFaceDeclaration' where
+  assoc _ v =
+    let
+      desc = Proxy :: _ d
+    in
+      tell (pure $ FontFaceDeclaration' $ val desc /\ fdval desc v) *> pure desc
+
+infixr 0 assoc as :=
+
+concatDeclarations :: List (Val /\ Val) -> Val
 concatDeclarations decls = Val \c ->
   let
     indent = String.joinWith mempty $ replicate c.indentLevel c.indentation
-    block' i' acc (k /\ v) =
-      indent
-        <> runVal c k
-        <> ":"
-        <> c.separator
-        <> runVal c v
-        <> (if (i' == 0 && c.finalSemicolon) || acc /= mempty then ";" else mempty)
-        <> if acc /= mempty then c.newline <> acc else mempty
+    go Nil acc = acc <> if c.finalSemicolon then ";" else mempty
+    go ((k /\ v) : xs) acc =
+      go xs $ (if acc /= mempty then acc <> ";" <> c.newline else mempty) <> indent <> runVal c k <> ":" <> c.separator <> runVal c v
   in
-    foldlWithIndex block' mempty decls
+    go decls mempty
 
 class Property (p :: Symbol)
 
 class Property p <= Declaration (p :: Symbol) (v :: Type) where
   pval :: Proxy p -> v -> Val
 
-class CollectDeclarations (rl :: RowList Type) (r :: Row Type) where
-  collectDeclarations
-    :: Proxy rl
-    -> Record r
-    -> List (Val /\ Val)
-    -> List (Val /\ Val)
-
-instance CollectDeclarations RL.Nil r where
-  collectDeclarations _ _ = identity
-
-instance
-  ( IsSymbol p
-  , Property p
-  , Row.Cons p CommonKeyword tailRow row
-  , CollectDeclarations tailRowList row
-  ) =>
-  CollectDeclarations (RL.Cons p CommonKeyword tailRowList) row where
-  collectDeclarations _ rec acc =
-    let
-      field = Proxy :: _ p
-      decl = val field /\ val (Record.get field rec)
-    in
-      collectDeclarations (Proxy :: _ tailRowList) rec $ decl : acc
-else instance
-  ( IsSymbol p
-  , Declaration p v
-  , Row.Cons p v tailRow row
-  , CollectDeclarations tailRowList row
-  ) =>
-  CollectDeclarations (RL.Cons p v tailRowList) row where
-  collectDeclarations _ rec acc =
-    let
-      field = Proxy :: _ p
-      decl = val field /\ pval field (Record.get field rec)
-    in
-      collectDeclarations (Proxy :: _ tailRowList) rec $ decl : acc
-
 --------------------------------------------------------------------------------
 
 -- Rendering
 
-renderInline
-  :: forall r rl empty
-   . RowToList r rl
-  => CollectDeclarations rl r
-  => BuildFromScratch empty (Record r)
-  => Builder (Record empty) (Record r)
+renderInline'
+  :: forall ps
+   . Configuration
+  -> Writer (List Declaration') ps
   -> String
-renderInline = render pretty { newline = " ", finalSemicolon = false }
+renderInline' c =
+  runVal c
+    <<< concatDeclarations
+    <<< map (\(Declaration' d) -> d)
+    <<< execWriter
+
+renderInline :: forall ps. Writer (List Declaration') ps -> String
+renderInline = renderInline' pretty { newline = " ", finalSemicolon = false }
 
 renderSheet :: Configuration -> Writer (Array Statement) Unit -> String
-renderSheet = render
+renderSheet config =
+  runVal config
+    <<< joinVals config.newline
+    <<< map renderStatement
+    <<< execWriter
 
-class Render (a :: Type) where
-  render :: Configuration -> a -> String
+  where
 
-instance Render (Writer (Array Statement) Unit) where
-  render config =
-    runVal config
-      <<< joinVals config.newline
-      <<< map renderStatement
-      <<< execWriter
-
-    where
-
-    renderStatement =
-      case _ of
-        Ruleset selectors declarations ->
-          let
-            selector =
-              joinVals (Val \c -> "," <> c.separator)
-                $ Array.fromFoldable selectors
-          in
-            nested selector declarations
-        NestedAtRule (NestedRule nestedRule) statements ->
-          nested (val "@" <> nestedRule) $
-            joinVals config.newline (renderStatement <$> statements)
-
-    nested outer inner =
-      Val \c@{ indentLevel, indentation, newline, separator } ->
+  renderStatement =
+    case _ of
+      Ruleset selectors declarations ->
         let
-          indent = String.joinWith mempty $ replicate indentLevel indentation
+          selector =
+            joinVals (Val \c -> "," <> c.separator)
+              $ Array.fromFoldable selectors
         in
-          indent
-            <> runVal c outer
-            <> separator
-            <> "{"
-            <> newline
-            <> runVal (c { indentLevel = indentLevel + 1 }) inner
-            <> newline
-            <> indent
-            <> "}"
+          nested selector declarations
+      NestedAtRule (NestedRule nestedRule) statements ->
+        nested (val "@" <> nestedRule) $
+          joinVals config.newline (renderStatement <$> statements)
 
-else instance
-  ( RowToList r rl
-  , CollectDeclarations rl r
-  , BuildFromScratch empty (Record r)
-  ) =>
-  Render (Builder (Record empty) (Record r)) where
-  render c decls =
-    runVal c
-      $ concatDeclarations
-      $ collectDeclarations (Proxy :: _ rl) (buildFromScratch decls) Nil
-
-else instance ToVal a => Render a where
-  render = composeFlipped val <<< runVal
+  nested outer inner =
+    Val \c@{ indentLevel, indentation, newline, separator } ->
+      let
+        indent = String.joinWith mempty $ replicate indentLevel indentation
+      in
+        indent
+          <> runVal c outer
+          <> separator
+          <> "{"
+          <> newline
+          <> runVal (c { indentLevel = indentLevel + 1 }) inner
+          <> newline
+          <> indent
+          <> "}"
 
 --------------------------------------------------------------------------------
 
@@ -430,14 +392,14 @@ else instance declarationGapRow ::
 
 class Property p <= Animatable (p :: Symbol)
 
-class AllPropertiesAnimatable (ps :: RowList Type)
+class AllPropertiesAnimatable (ps :: Type)
 
-instance AllPropertiesAnimatable RL.Nil
 instance
   ( Animatable p
-  , AllPropertiesAnimatable tail
+  , AllPropertiesAnimatable ps
   ) =>
-  AllPropertiesAnimatable (RL.Cons p v tail)
+  AllPropertiesAnimatable (Proxy p /\ ps)
+else instance Animatable p => AllPropertiesAnimatable (Proxy p)
 
 newtype KeyframesName = KeyframesName String
 
@@ -2192,31 +2154,6 @@ instance declarationAlignContent ::
 
 class FontFaceDeclaration (d :: Symbol) (v :: Type) where
   fdval :: Proxy d -> v -> Val
-
-class CollectFontFaceDeclarations (rl :: RowList Type) (r :: Row Type) (provided :: Row Type) | rl -> provided where
-  collectFontFaceDeclarations
-    :: Proxy rl
-    -> Record r
-    -> List (Val /\ Val)
-    -> List (Val /\ Val)
-
-instance CollectFontFaceDeclarations RL.Nil r () where
-  collectFontFaceDeclarations _ _ = identity
-
-instance
-  ( IsSymbol d
-  , FontFaceDeclaration d v
-  , Row.Cons d v tailRow row
-  , CollectFontFaceDeclarations tailRowList row tailProvided
-  , Row.Cons d Unit tailProvided provided
-  ) =>
-  CollectFontFaceDeclarations (RL.Cons d v tailRowList) row provided where
-  collectFontFaceDeclarations _ rec acc =
-    let
-      field = Proxy :: _ d
-      decl = val field /\ fdval field (Record.get field rec)
-    in
-      collectFontFaceDeclarations (Proxy :: _ tailRowList) rec $ decl : acc
 
 data FontFace = FontFace
 

--- a/src/Tecton/Rule.purs
+++ b/src/Tecton/Rule.purs
@@ -1,7 +1,13 @@
 module Tecton.Rule where
 
 import Prelude hiding (discard)
-import Record.Builder (Builder)
+import Control.Monad.Writer (Writer)
+import Data.Tuple.Nested (type (/\), (/\))
 
-discard :: forall a b c. Builder a b -> (Unit -> Builder b c) -> Builder a c
-discard a k = a >>> k unit
+discard
+  :: forall w a b
+   . Monoid w
+  => Writer w a
+  -> (a -> Writer w b)
+  -> Writer w (a /\ b)
+discard wa awb = wa >>= \a -> awb a >>= \b -> pure (a /\ b)

--- a/test.dhall
+++ b/test.dhall
@@ -2,5 +2,5 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # ["test/**/*.purs"],
-  dependencies = conf.dependencies # ["aff", "effect", "exceptions", "spec"]
+  dependencies = conf.dependencies # ["aff", "effect", "spec"]
 }

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (columnGap, inherit, gap, initial, normal, pct, px, rowGap, unset, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Box Alignment Module" do
 
     describe "row-gap property" do

--- a/test/AnimationsSpec.purs
+++ b/test/AnimationsSpec.purs
@@ -7,13 +7,15 @@ import Prelude
 import Data.Tuple.Nested ((/\))
 import Tecton (all, alternate, alternateReverse, animationDelay, animationDirection, animationDuration, animationFillMode, animationIterationCount, animationName, animationPlayState, animationTimingFunction, backwards, both, cubicBezier, ease, easeIn, easeInOut, easeOut, end, forwards, infinite, inherit, initial, jumpBoth, jumpEnd, jumpNone, jumpStart, keyframes, keyframesName, linear, media, ms, nil, none, normal, paused, pct, px, reverse, running, sec, start, stepEnd, stepStart, steps, unset, width, (?), (:=), (@+@), (@*), (@/))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline, isRenderedFromSheet)
 
 spec :: Spec Unit
 spec =
   describe "Animations Module" do
 
     describe "Keyframes" do
+
+      let isRenderedFrom = isRenderedFromSheet
 
       "@keyframes foo{0%{width:0}100%{width:500px}}"
         `isRenderedFrom` do
@@ -36,6 +38,8 @@ spec =
 
     describe "animation-name property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "animation-name:inherit" `isRenderedFrom` (animationName := inherit)
 
       "animation-name:initial" `isRenderedFrom` (animationName := initial)
@@ -51,6 +55,8 @@ spec =
         (animationName := keyframesName "foo" /\ none /\ keyframesName "bar")
 
     describe "animation-duration property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "animation-duration:inherit"
         `isRenderedFrom`
@@ -69,6 +75,8 @@ spec =
         (animationDuration := ms 150 /\ nil /\ sec 2)
 
     describe "animation-timing-function property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "animation-timing-function:inherit"
         `isRenderedFrom`
@@ -144,6 +152,8 @@ spec =
 
     describe "animation-iteration-count property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "animation-iteration-count:infinite"
         `isRenderedFrom`
         (animationIterationCount := infinite)
@@ -157,6 +167,8 @@ spec =
         (animationIterationCount := 3 /\ infinite /\ 2)
 
     describe "animation-direction property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "animation-direction:inherit"
         `isRenderedFrom`
@@ -190,6 +202,8 @@ spec =
 
     describe "animation-play-state property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "animation-play-state:inherit"
         `isRenderedFrom`
         (animationPlayState := inherit)
@@ -216,6 +230,8 @@ spec =
 
     describe "animation-delay property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "animation-delay:inherit" `isRenderedFrom` (animationDelay := inherit)
 
       "animation-delay:initial" `isRenderedFrom` (animationDelay := initial)
@@ -229,6 +245,8 @@ spec =
         (animationDelay := ms 150 /\ nil /\ sec 2)
 
     describe "animation-fill-mode property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "animation-fill-mode:inherit"
         `isRenderedFrom`

--- a/test/BackgroundsSpec.purs
+++ b/test/BackgroundsSpec.purs
@@ -8,10 +8,13 @@ import Color (black, rgb, rgba, white)
 import Data.Tuple.Nested ((/\))
 import Tecton (auto, backgroundAttachment, backgroundClip, backgroundColor, backgroundImage, backgroundOrigin, backgroundPosition, backgroundRepeat, backgroundSize, borderBox, borderBottomColor, borderBottomLeftRadius, borderBottomRightRadius, borderBottomStyle, borderBottomWidth, borderColor, borderLeftColor, borderLeftStyle, borderLeftWidth, borderRadius, borderRightColor, borderRightStyle, borderRightWidth, borderStyle, borderTopColor, borderTopLeftRadius, borderTopRightRadius, borderTopStyle, borderTopWidth, borderWidth, bottom, boxShadow, center, circle, contain, contentBox, cover, currentColor, dashed, dotted, double, fixed, groove, hidden, inherit, initial, inset, left, local', medium, nil, noRepeat, none, outset, paddingBox, pct, px, radialGradient, repeat', repeatX, repeatY, ridge, right, round, scroll, solid, space, thick, thin, top, transparent, unset, url, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Backgrounds and Borders Module" do
 
     describe "background-color property" do

--- a/test/BoxSpec.purs
+++ b/test/BoxSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (auto, em, inherit, initial, margin, marginBottom, marginLeft, marginRight, marginTop, padding, paddingBottom, paddingLeft, paddingRight, paddingTop, pct, px, unset, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Box Module" do
 
     describe "margin-top property" do

--- a/test/ColorSpec.purs
+++ b/test/ColorSpec.purs
@@ -5,10 +5,13 @@ import Prelude
 import Color (hsl)
 import Tecton (color, currentColor, inherit, initial, opacity, transparent, unset, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Color Module" do
 
     describe "color property" do

--- a/test/ContentSpec.purs
+++ b/test/ContentSpec.purs
@@ -8,10 +8,13 @@ import Color (rgb)
 import Data.Tuple.Nested ((/\))
 import Tecton (content, contents, inherit, initial, linearGradient, nil, none, normal, unset, url, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Generated Content Module" do
 
     describe "content property" do

--- a/test/DisplaySpec.purs
+++ b/test/DisplaySpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (block, contents, display, flex, flowRoot, grid, inherit, initial, inline, inlineBlock, inlineFlex, inlineGrid, inlineTable, listItem, none, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup, unset, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Display Module" do
 
     describe "display property" do

--- a/test/FlexboxSpec.purs
+++ b/test/FlexboxSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (alignContent, alignItems, alignSelf, auto, baseline, center, column, columnReverse, content, em, fitContent, flex, flexBasis, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, inherit, initial, justifyContent, maxContent, minContent, none, nowrap, order, pct, px, row, rowReverse, spaceAround, spaceBetween, stretch, unset, wrap, wrapReverse, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Flexible Box Layout Module" do
 
     describe "flex-direction property" do

--- a/test/FontsSpec.purs
+++ b/test/FontsSpec.purs
@@ -8,13 +8,15 @@ import Data.Tuple.Nested ((/\))
 import Tecton (auto, bold, bolder, condensed, cursive, deg, emoji, expanded, extraCondensed, extraExpanded, fangsong, fantasy, fontFace, fontFamily, fontSize, fontSizeAdjust, fontStretch, fontStyle, fontWeight, format, inherit, initial, italic, large, larger, lighter, local, math, medium, monospace, normal, oblique, pct, px, sansSerif, semiCondensed, semiExpanded, serif, small, smaller, src, svg, systemUI, uiMonospace, uiRounded, uiSansSerif, uiSerif, ultraCondensed, ultraExpanded, unset, url, woff, xLarge, xSmall, xxLarge, xxSmall, (:=), (?), (~))
 import Tecton.Rule as Rule
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline, isRenderedFromSheet)
 
 spec :: Spec Unit
 spec =
   describe "Fonts Module" do
 
     describe "font-family property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "font-family:inherit" `isRenderedFrom` (fontFamily := inherit)
 
@@ -54,6 +56,8 @@ spec =
 
     describe "font-weight property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "font-weight:inherit" `isRenderedFrom` (fontWeight := inherit)
 
       "font-weight:initial" `isRenderedFrom` (fontWeight := initial)
@@ -72,7 +76,9 @@ spec =
 
       "font-weight:lighter" `isRenderedFrom` (fontWeight := lighter)
 
-    describe "font-stretch" do
+    describe "font-stretch property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "font-stretch:inherit" `isRenderedFrom` (fontStretch := inherit)
 
@@ -114,6 +120,8 @@ spec =
 
     describe "font-style property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "font-style:inherit" `isRenderedFrom` (fontStyle := inherit)
 
       "font-style:initial" `isRenderedFrom` (fontStyle := initial)
@@ -124,15 +132,13 @@ spec =
 
       "font-style:italic" `isRenderedFrom` (fontStyle := italic)
 
-      "font-style:oblique"
-        `isRenderedFrom`
-        (fontStyle := oblique)
+      "font-style:oblique" `isRenderedFrom` (fontStyle := oblique)
 
-      "font-style:oblique 7deg"
-        `isRenderedFrom`
-        (fontStyle := oblique ~ deg 7)
+      "font-style:oblique 7deg" `isRenderedFrom` (fontStyle := oblique ~ deg 7)
 
     describe "font-size property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "font-size:inherit" `isRenderedFrom` (fontSize := inherit)
 
@@ -164,6 +170,8 @@ spec =
 
     describe "font-size-adjust property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "font-size-adjust:inherit" `isRenderedFrom` (fontSizeAdjust := inherit)
 
       "font-size-adjust:initial" `isRenderedFrom` (fontSizeAdjust := initial)
@@ -174,6 +182,8 @@ spec =
 
     describe "font-face rule" do
 
+      let isRenderedFrom = isRenderedFromSheet
+
       "@font-face{font-family:\"Foo\";src:url(\"./foo.woff\")}"
         `isRenderedFrom` do
         fontFace ? Rule.do
@@ -182,6 +192,8 @@ spec =
 
     describe "font-family descriptor" do
 
+      let isRenderedFrom = isRenderedFromSheet
+
       "@font-face{font-family:\"Roboto\";src:url(\"./foo.woff\")}"
         `isRenderedFrom` do
         fontFace ? Rule.do
@@ -189,6 +201,8 @@ spec =
           src := url "./foo.woff"
 
     describe "src descriptor" do
+
+      let isRenderedFrom = isRenderedFromSheet
 
       "@font-face{font-family:\"Foo\";src:url(\"./Gentium.svg\") format(\"svg\")}"
         `isRenderedFrom` do
@@ -204,42 +218,44 @@ spec =
 
     describe "font-style descriptor" do
 
-      "@font-face{font-family:\"Foo\";font-style:auto;src:local(\"Foo\")}"
+      let isRenderedFrom = isRenderedFromSheet
+
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-style:auto}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStyle := auto
 
-      "@font-face{font-family:\"Foo\";font-style:normal;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-style:normal}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStyle := normal
 
-      "@font-face{font-family:\"Foo\";font-style:italic;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-style:italic}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStyle := italic
 
-      "@font-face{font-family:\"Foo\";font-style:oblique;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-style:oblique}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStyle := oblique
 
-      "@font-face{font-family:\"Foo\";font-style:oblique 15deg;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-style:oblique 15deg}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStyle := oblique ~ deg 15
 
-      "@font-face{font-family:\"Foo\";font-style:oblique 10deg 20deg;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-style:oblique 10deg 20deg}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
@@ -248,70 +264,72 @@ spec =
 
     describe "font-weight descriptor" do
 
-      "@font-face{font-family:\"Foo\";font-weight:auto;src:local(\"Foo\")}"
+      let isRenderedFrom = isRenderedFromSheet
+
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:auto}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := auto
 
-      "@font-face{font-family:\"Foo\";font-weight:normal;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:normal}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := normal
 
-      "@font-face{font-family:\"Foo\";font-weight:bold;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:bold}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := bold
 
-      "@font-face{font-family:\"Foo\";font-weight:1;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:1}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := 1
 
-      "@font-face{font-family:\"Foo\";font-weight:1000;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:1000}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := 1000
 
-      "@font-face{font-family:\"Foo\";font-weight:200 400;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:200 400}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := 200 ~ 400
 
-      "@font-face{font-family:\"Foo\";font-weight:200 normal;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:200 normal}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := 200 ~ normal
 
-      "@font-face{font-family:\"Foo\";font-weight:500 bold;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:500 bold}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := 500 ~ bold
 
-      "@font-face{font-family:\"Foo\";font-weight:normal 600;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:normal 600}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontWeight := normal ~ 600
 
-      "@font-face{font-family:\"Foo\";font-weight:bold 900;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-weight:bold 900}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
@@ -320,98 +338,100 @@ spec =
 
     describe "font-stretch descriptor" do
 
-      "@font-face{font-family:\"Foo\";font-stretch:auto;src:local(\"Foo\")}"
+      let isRenderedFrom = isRenderedFromSheet
+
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:auto}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := auto
 
-      "@font-face{font-family:\"Foo\";font-stretch:normal;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:normal}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := normal
 
-      "@font-face{font-family:\"Foo\";font-stretch:110%;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:110%}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := pct 110
 
-      "@font-face{font-family:\"Foo\";font-stretch:ultra-condensed;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:ultra-condensed}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := ultraCondensed
 
-      "@font-face{font-family:\"Foo\";font-stretch:extra-condensed;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:extra-condensed}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := extraCondensed
 
-      "@font-face{font-family:\"Foo\";font-stretch:condensed;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:condensed}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := condensed
 
-      "@font-face{font-family:\"Foo\";font-stretch:semi-condensed;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:semi-condensed}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := semiCondensed
 
-      "@font-face{font-family:\"Foo\";font-stretch:semi-expanded;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:semi-expanded}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := semiExpanded
 
-      "@font-face{font-family:\"Foo\";font-stretch:expanded;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:expanded}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := expanded
 
-      "@font-face{font-family:\"Foo\";font-stretch:extra-expanded;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:extra-expanded}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := extraExpanded
 
-      "@font-face{font-family:\"Foo\";font-stretch:ultra-expanded;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:ultra-expanded}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := ultraExpanded
 
-      "@font-face{font-family:\"Foo\";font-stretch:normal expanded;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:normal expanded}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := normal ~ expanded
 
-      "@font-face{font-family:\"Foo\";font-stretch:expanded ultra-expanded;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:expanded ultra-expanded}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"
           src := local "Foo"
           fontStretch := expanded ~ ultraExpanded
 
-      "@font-face{font-family:\"Foo\";font-stretch:condensed 110%;src:local(\"Foo\")}"
+      "@font-face{font-family:\"Foo\";src:local(\"Foo\");font-stretch:condensed 110%}"
         `isRenderedFrom` do
         fontFace ? Rule.do
           fontFamily := "Foo"

--- a/test/ImagesSpec.purs
+++ b/test/ImagesSpec.purs
@@ -8,10 +8,13 @@ import Color (black, rgb)
 import Data.Tuple.Nested ((/\))
 import Tecton (bottom, center, circle, closestSide, currentColor, deg, ellipse, farthestCorner, left, linearGradient, nil, pct, px, radialGradient, repeating, right, top, transparent, (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromVal)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromVal
+
   describe "Images Module" do
 
     describe "linear-gradient()" do

--- a/test/InlineSpec.purs
+++ b/test/InlineSpec.purs
@@ -6,10 +6,13 @@ import Prelude hiding (bottom, sub, top)
 
 import Tecton (alignmentBaseline, alphabetic, auto, baseline, baselineShift, baselineSource, bottom, center, central, dominantBaseline, first, hanging, ideographic, inherit, initial, last, lineHeight, mathematical, middle, normal, pct, px, sub, super, textBottom, textTop, top, unset, verticalAlign, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Inline Layout Module" do
 
     describe "dominant-baseline property" do

--- a/test/ListsSpec.purs
+++ b/test/ListsSpec.purs
@@ -8,7 +8,7 @@ import Color (rgb)
 import Data.Tuple.Nested ((/\))
 import Tecton (arabicIndic, armenian, bengali, cambodian, center, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, decimal, decimalLeadingZero, devanagari, disc, disclosureClosed, disclosureOpen, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, inherit, initial, inside, listStyleImage, listStylePosition, listStyleType, kannada, katakana, katakanaIroha, khmer, lao, li, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, marker, mongolian, myanmar, nil, none, oriya, outside, persian, radialGradient, square, tamil, telugu, thai, tibetan, unset, upperAlpha, upperArmenian, upperLatin, upperRoman, url, width, (:=), (&:), (?))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline, isRenderedFromSheet)
 
 spec :: Spec Unit
 spec =
@@ -16,11 +16,15 @@ spec =
 
     describe "marker pseudo-element" do
 
+      let isRenderedFrom = isRenderedFromSheet
+
       "li::marker{width:0}"
         `isRenderedFrom` do
         li &: marker ? width := nil
 
     describe "list-style-image property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "list-style-image:inherit" `isRenderedFrom` (listStyleImage := inherit)
 
@@ -41,6 +45,8 @@ spec =
        )
 
     describe "list-style-type property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "list-style-type:inherit" `isRenderedFrom` (listStyleType := inherit)
 
@@ -181,6 +187,8 @@ spec =
         (listStyleType := cjkHeavenlyStem)
 
     describe "list-style-position property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "list-style-position:inherit"
         `isRenderedFrom`

--- a/test/MaskingSpec.purs
+++ b/test/MaskingSpec.purs
@@ -8,10 +8,13 @@ import Color (rgb)
 import Data.Tuple.Nested ((/\))
 import Tecton (inherit, initial, linearGradient, maskImage, nil, none, unset, url, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Masking Module" do
 
     describe "mask-image property" do

--- a/test/MediaQueriesSpec.purs
+++ b/test/MediaQueriesSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (all, dpcm, dpi, landscape, media, nil, portrait, print, px, screen, universal, width, (:/), (?), (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromSheet)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromSheet
+
   describe "Media Queries Module" do
 
     describe "Media types" do

--- a/test/OverflowSpec.purs
+++ b/test/OverflowSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (auto, clip, ellipsis, hidden, inherit, initial, overflow, overflowX, overflowY, scroll, textOverflow, unset, visible, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Overflow Module" do
 
     describe "overflow-x property" do

--- a/test/PositionSpec.purs
+++ b/test/PositionSpec.purs
@@ -6,10 +6,13 @@ import Prelude hiding (bottom, top)
 
 import Tecton (absolute, auto, bottom, fixed, inherit, initial, inset, insetBlock, insetBlockEnd, insetBlockStart, insetInline, insetInlineEnd, insetInlineStart, left, nil, pct, position, px, relative, right, static, sticky, top, unset, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Positioned Layout Module" do
 
     describe "position property" do

--- a/test/RenderSpec.purs
+++ b/test/RenderSpec.purs
@@ -18,7 +18,7 @@ spec = do
             width := nil
             height := nil
         in
-          inlineStyles `shouldEqual` "height: 0; width: 0"
+          inlineStyles `shouldEqual` "width: 0; height: 0"
 
   describe "renderSheet" do
     it "renders a compact style sheet" $

--- a/test/SelectorsSpec.purs
+++ b/test/SelectorsSpec.purs
@@ -9,10 +9,13 @@ import Prelude hiding (not)
 import Data.Tuple.Nested ((/\))
 import Tecton (a, active, after, att, before, checked, disabled, empty, enabled, even, firstChild, firstLetter, firstLine, firstOfType, focus, hover, href, hreflang, indeterminate, lang, lastChild, lastOfType, link, nil, not, nth, nthChild, nthLastChild, nthOfType, odd, onlyChild, onlyOfType, placeholder, root, selection, span, target, title, universal, visited, width, ($=), (&#), (&.), (&:), (&@), (*=), (?), (@=), (^=), (|*), (|+), (|=), (|>), (|~), (~=), (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromSheet)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromSheet
+
   describe "Selectors Module" do
 
     describe "Universal selector" do
@@ -25,7 +28,7 @@ spec =
 
       "span{width:0}" `isRenderedFrom` do span ? width := nil
 
-    describe "Attribute seectors" do
+    describe "Attribute selectors" do
 
       "*[href]{width:0}"
         `isRenderedFrom` do

--- a/test/SizingSpec.purs
+++ b/test/SizingSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (auto, fitContent, height, inherit, initial, maxContent, minContent, maxHeight, maxWidth, minHeight, minWidth, none, pct, px, unset, width, (:=), (@+@))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Box Sizing Module" do
 
     describe "width property" do

--- a/test/TextDecorSpec.purs
+++ b/test/TextDecorSpec.purs
@@ -8,10 +8,13 @@ import Color (rgb)
 import Data.Tuple.Nested ((/\))
 import Tecton (blink, dashed, dotted, double, em, inherit, initial, lineThrough, nil, none, overline, px, solid, textDecorationColor, textDecorationLine, textDecorationStyle, textShadow, underline, unset, wavy, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Text Decoration Module" do
 
     describe "text-decoration-line" do

--- a/test/TextSpec.purs
+++ b/test/TextSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (breakSpaces, capitalize, center, em, end, fullSizeKana, fullWidth, inherit, initial, justify, justifyAll, left, letterSpacing, lowercase, matchParent, none, normal, nowrap, pre, preLine, preWrap, pct, px, right, start, textAlign, textIndent, textTransform, unset, uppercase, whiteSpace, wordSpacing, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Text Module" do
 
     describe "text-transform property" do

--- a/test/TransformsSpec.purs
+++ b/test/TransformsSpec.purs
@@ -8,13 +8,15 @@ import Prelude hiding (top, bottom)
 import Data.Tuple.Nested ((/\))
 import Tecton (bottom, center, deg, inherit, initial, left, matrix, matrix3d, none, pct, perspective, px, rad, right, rotate, rotate3d, rotateX, rotateY, rotateZ, scale, scale3d, scaleX, scaleY, scaleZ, skewX, skewY, top, transform, transformOrigin, translate, translate3d, translateX, translateY, translateZ, turn, unset, (:=), (~))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline, isRenderedFromVal)
 
 spec :: Spec Unit
 spec =
   describe "Transforms Module" do
 
     describe "2D Transform Functions" do
+
+      let isRenderedFrom = isRenderedFromVal
 
       "matrix(1.2,0.2,-1,0.9,0,20)"
         `isRenderedFrom`
@@ -55,6 +57,8 @@ spec =
       "skewY(75deg)" `isRenderedFrom` skewY (deg 75)
 
     describe "3D Transform Functions" do
+
+      let isRenderedFrom = isRenderedFromVal
 
       "matrix3d(-0.6,1.34788,0,0,-2.34788,-0.6,0,0,0,0,1,0,0,0,10,1)"
         `isRenderedFrom`
@@ -104,6 +108,8 @@ spec =
 
     describe "transform property" do
 
+      let isRenderedFrom = isRenderedFromInline
+
       "transform:inherit" `isRenderedFrom` (transform := inherit)
 
       "transform:initial" `isRenderedFrom` (transform := initial)
@@ -119,6 +125,8 @@ spec =
         (transform := rotateX (deg 45) /\ translateX (px (-10)) /\ scaleX 1.5)
 
     describe "transform-origin property" do
+
+      let isRenderedFrom = isRenderedFromInline
 
       "transform-origin:inherit" `isRenderedFrom` (transformOrigin := inherit)
 

--- a/test/TransitionsSpec.purs
+++ b/test/TransitionsSpec.purs
@@ -7,10 +7,13 @@ import Prelude hiding (top, bottom)
 import Data.Tuple.Nested ((/\))
 import Tecton (all, bottom, cubicBezier, ease, easeIn, easeInOut, easeOut, end, flex, height, inherit, initial, inset, jumpBoth, jumpEnd, jumpNone, jumpStart, left, marginTop, ms, nil, none, right, sec, start, stepEnd, stepStart, steps, transitionDelay, transitionDuration, transitionProperty, transitionTimingFunction, top, unset, width, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Transitions" do
 
     describe "transition-property property" do

--- a/test/UISpec.purs
+++ b/test/UISpec.purs
@@ -7,10 +7,13 @@ import Prelude
 import Color (rgb)
 import Tecton (auto, dashed, dotted, double, groove, inherit, initial, inset, invert, medium, nil, none, outlineColor, outlineOffset, outlineStyle, outlineWidth, outset, px, ridge, solid, thick, thin, transparent, unset, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Basic User Interface Module" do
 
     describe "outline-width property" do

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -2,21 +2,35 @@ module Test.Util where
 
 import Prelude
 
-import Control.Monad.Error.Class (class MonadThrow)
-import Effect.Exception (Error)
-import Tecton.Internal (class Render, compact, render)
+import Control.Monad.Writer (Writer)
+import Data.List (List)
+import Tecton.Internal (class ToVal, Declaration', Statement, compact, renderInline', renderSheet, runVal, val)
 import Test.Spec (Spec, it)
 import Test.Spec.Assertions (shouldEqual)
 
-isRenderedFrom :: forall a. Render a => String -> a -> Spec Unit
-isRenderedFrom expected given =
-  it ("renders " <> expected) $ assertRendered expected given
+isRenderedFromInline
+  :: forall ps
+   . String
+  -> Writer (List Declaration') ps
+  -> Spec Unit
+isRenderedFromInline expected given =
+  it ("renders " <> expected) $
+    renderInline' compact given `shouldEqual` expected
 
-assertRendered
-  :: forall m a
-   . MonadThrow Error m
- => Render a
- => String
- -> a
- -> m Unit
-assertRendered expected given = render compact given `shouldEqual` expected
+isRenderedFromSheet
+  :: String
+  -> Writer (Array Statement) Unit
+  -> Spec Unit
+isRenderedFromSheet expected given =
+  it ("renders " <> expected) $
+    renderSheet compact given `shouldEqual` expected
+
+isRenderedFromVal
+  :: forall a
+   . ToVal a
+  => String
+  -> a
+  -> Spec Unit
+isRenderedFromVal expected given =
+  it ("renders " <> expected) $
+    runVal compact (val given) `shouldEqual` expected

--- a/test/VisufxSpec.purs
+++ b/test/VisufxSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (collapse, hidden, inherit, initial, unset, visibility, visible, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+  
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Visual Effects" do
 
     describe "visibility property" do

--- a/test/VisurenSpec.purs
+++ b/test/VisurenSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (auto, both, clear, float, inherit, initial, left, none, right, unset, zIndex, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Visual Formatting Model" do
 
     describe "float property" do

--- a/test/WritingModesSpec.purs
+++ b/test/WritingModesSpec.purs
@@ -6,10 +6,13 @@ import Prelude
 
 import Tecton (direction, inherit, initial, ltr, rtl, unset, (:=))
 import Test.Spec (Spec, describe)
-import Test.Util (isRenderedFrom)
+import Test.Util (isRenderedFromInline)
 
 spec :: Spec Unit
-spec =
+spec = do
+  
+  let isRenderedFrom = isRenderedFromInline
+
   describe "Writing Modes Module" do
 
     describe "direction property" do


### PR DESCRIPTION
### Description

This pull request implements a fix for the [declaration ordering issue](https://github.com/nsaunders/purescript-tecton/blob/9d9c01cc35c4744b33541f8e8e5403410db06645/docs/caveats.md#Declaration-ordering) related to the fact that declarations are assigned to a record.

### Design considerations

It remains important to track which properties exist in a given ruleset, in order to enforce:
* keyframe blocks only containing animatable properties
* font-face rules including the minimum required `font-family` and `src` properties

For this reason, the `Rule.do` syntax remains so that the associated `discard` function can collect the list of properties.

### Future plans

A trade-off here is that the same property can now be duplicated within a ruleset. This should be fixed soon.

### References

* [Caveats](https://github.com/nsaunders/purescript-tecton/blob/9d9c01cc35c4744b33541f8e8e5403410db06645/docs/caveats.md#Declaration-ordering)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
