### PR TITLE
Grid support; closes #3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 Breaking changes:
 
 New features:
+- Grid support / new CSS properties
+  - `grid-auto-columns`
+  - `grid-auto-flow`
+  - `grid-auto-rows`
+  - `grid-column-end`
+  - `grid-column-start`
+  - `grid-row-end`
+  - `grid-row-start`
+  - `grid-template-columns`
+  - `grid-template-rows`
+- Flexbox properties extended to support additional values defined in
+  [Box Alignment Module Level 3](https://www.w3.org/TR/css-align-3)
+  - `justify-content`
+  - `align-content`
+  - `justify-self`
+  - `align-self`
+  - `justify-items`
+  - `align-items`
 
 Bugfixes:
 

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -293,6 +293,7 @@ import Tecton.Internal
   , justify
   , justifyAll
   , justifyContent
+  , justifyItems
   , justifySelf
   , kannada
   , katakana
@@ -312,6 +313,7 @@ import Tecton.Internal
   , lastChild
   , lastOfType
   , left
+  , legacy
   , legend
   , letterSpacing
   , li

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -230,6 +230,9 @@ import Tecton.Internal
   , gridAutoColumns
   , gridAutoFlow
   , gridAutoRows
+  , gridColumnEnd
+  , gridColumnStart
+  , gridRowEnd
   , gridRowStart
   , gridTemplateColumns
   , gridTemplateRows

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -293,6 +293,7 @@ import Tecton.Internal
   , justify
   , justifyAll
   , justifyContent
+  , justifySelf
   , kannada
   , katakana
   , katakanaIroha
@@ -546,6 +547,7 @@ import Tecton.Internal
   , rowspan
   , rtl
   , running
+  , safe
   , sandbox
   , sansSerif
   , scale
@@ -561,6 +563,8 @@ import Tecton.Internal
   , select
   , selected
   , selection
+  , selfEnd
+  , selfStart
   , semiCondensed
   , semiExpanded
   , serif
@@ -660,6 +664,7 @@ import Tecton.Internal
   , ultraExpanded
   , underline
   , universal
+  , unsafe
   , unset
   , upperAlpha
   , upperArmenian

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -230,6 +230,7 @@ import Tecton.Internal
   , gridAutoColumns
   , gridAutoFlow
   , gridAutoRows
+  , gridRowStart
   , gridTemplateColumns
   , gridTemplateRows
   , groove

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -145,6 +145,7 @@ import Tecton.Internal
   , default
   , defer
   , deg
+  , dense
   , details
   , devanagari
   , dir
@@ -227,6 +228,7 @@ import Tecton.Internal
   , georgian
   , grid
   , gridAutoColumns
+  , gridAutoFlow
   , gridAutoRows
   , gridTemplateColumns
   , gridTemplateRows

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -226,6 +226,8 @@ import Tecton.Internal
   , gap
   , georgian
   , grid
+  , gridAutoColumns
+  , gridAutoRows
   , gridTemplateColumns
   , gridTemplateRows
   , groove

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -581,6 +581,7 @@ import Tecton.Internal
   , space
   , spaceAround
   , spaceBetween
+  , spaceEvenly
   , span
   , spellcheck
   , square

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -40,6 +40,8 @@ import Tecton.Internal
   , att
   , audio
   , auto
+  , autoFill
+  , autoFit
   , autocomplete
   , autofocus
   , autoplay
@@ -218,11 +220,14 @@ import Tecton.Internal
   , formaction
   , format
   , forwards
+  , fr
   , fullSizeKana
   , fullWidth
   , gap
   , georgian
   , grid
+  , gridTemplateColumns
+  , gridTemplateRows
   , groove
   , gujarati
   , gurmukhi
@@ -304,6 +309,7 @@ import Tecton.Internal
   , lighter
   , line
   , lineHeight
+  , lineName
   , lineThrough
   , linear
   , linearGradient
@@ -354,6 +360,7 @@ import Tecton.Internal
   , minContent
   , minHeight
   , minWidth
+  , minmax
   , mm
   , mongolian
   , monospace
@@ -506,6 +513,7 @@ import Tecton.Internal
   , rem
   , renderInline
   , renderSheet
+  , repeat
   , repeat'
   , repeatX
   , repeatY

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -126,6 +126,7 @@ module Tecton.Internal
   , class MultiVal
   , class OutlineLineStyleKeyword
   , class OverflowKeyword
+  , class OverflowPositionKeyword
   , class PercentageTag
   , class PositionKeyword
   , class Property
@@ -137,6 +138,7 @@ module Tecton.Internal
   , class RepeatStyle2dKeyword
   , class RepeatTrackList
   , class SelectorStatus
+  , class SelfPositionKeyword
   , class ShapeKeyword
   , class StepPosition
   , class TextAlignKeyword
@@ -516,6 +518,7 @@ module Tecton.Internal
   , justify
   , justifyAll
   , justifyContent
+  , justifySelf
   , kannada
   , katakana
   , katakanaIroha
@@ -778,6 +781,7 @@ module Tecton.Internal
   , rtl
   , runVal
   , running
+  , safe
   , sandbox
   , sansSerif
   , scale
@@ -793,6 +797,8 @@ module Tecton.Internal
   , select
   , selected
   , selection
+  , selfEnd
+  , selfStart
   , semiCondensed
   , semiExpanded
   , serif
@@ -893,6 +899,7 @@ module Tecton.Internal
   , ultraExpanded
   , underline
   , universal
+  , unsafe
   , unset
   , upperAlpha
   , upperArmenian
@@ -1310,6 +1317,94 @@ renderSheet config =
 
 -- Box Alignment
 -- https://www.w3.org/TR/css-align-3/
+
+-- https://www.w3.org/TR/css-align-3/#propdef-justify-self
+
+justifySelf = Proxy :: Proxy "justify-self"
+
+instance Property "justify-self"
+
+selfStart = Proxy :: Proxy "self-start"
+selfEnd = Proxy :: Proxy "self-end"
+
+class SelfPositionKeyword (s :: Symbol)
+
+instance SelfPositionKeyword "center"
+instance SelfPositionKeyword "start"
+instance SelfPositionKeyword "end"
+instance SelfPositionKeyword "self-start"
+instance SelfPositionKeyword "self-end"
+instance SelfPositionKeyword "flex-start"
+instance SelfPositionKeyword "flex-end"
+
+safe = Proxy :: Proxy "safe"
+unsafe = Proxy :: Proxy "unsafe"
+
+class OverflowPositionKeyword (s :: Symbol)
+
+instance OverflowPositionKeyword "safe"
+instance OverflowPositionKeyword "unsafe"
+
+instance declarationJustifySelfFirstBaseline ::
+  Declaration "justify-self" (Proxy "first" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationJustifySelfLastBaseline ::
+  Declaration "justify-self" (Proxy "last" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationJustifySelfOverflowPositionKeywordLeft ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-self" (Proxy s ~ Proxy "left") where
+  pval = const val
+
+else instance declarationJustifySelfOverflowPositionKeywordRight ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-self" (Proxy s ~ Proxy "right") where
+  pval = const val
+
+else instance declarationJustifySelfOverflowPositionKeywordSelfPositionKeyword ::
+  ( OverflowPositionKeyword sa
+  , IsSymbol sa
+  , SelfPositionKeyword sb
+  , IsSymbol sb
+  ) =>
+  Declaration "justify-self" (Proxy sa ~ Proxy sb) where
+  pval = const val
+
+instance declarationJustifySelfAuto :: Declaration "justify-self" (Proxy "auto") where
+  pval = const val
+
+else instance declarationJustifySelfNormal ::
+  Declaration "justify-self" (Proxy "normal") where
+  pval = const val
+
+else instance declarationJustifySelfStretch ::
+  Declaration "justify-self" (Proxy "stretch") where
+  pval = const val
+
+else instance declarationJustifySelfBaseline ::
+  Declaration "justify-self" (Proxy "baseline") where
+  pval = const val
+
+else instance declarationJustifySelfLeft ::
+  Declaration "justify-self" (Proxy "left") where
+  pval = const val
+
+else instance declarationJustifySelfRight ::
+  Declaration "justify-self" (Proxy "right") where
+  pval = const val
+
+else instance declarationJustifySelfSelfPositionKeyword ::
+  ( SelfPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-self" (Proxy s) where
+  pval = const val
 
 -- https://www.w3.org/TR/css-align-3/#propdef-row-gap
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -449,6 +449,8 @@ module Tecton.Internal
   , generalSibling
   , georgian
   , grid
+  , gridAutoColumns
+  , gridAutoRows
   , gridTemplateColumns
   , gridTemplateRows
   , groove
@@ -3806,6 +3808,54 @@ else instance declarationGridTemplateRowsTrackList ::
   ) =>
   Declaration "grid-template-rows" tracks where
   pval = const $ intercalateMultiVal " " <<< foldLineNames
+
+-- https://www.w3.org/TR/css-grid-1/#propdef-grid-auto-columns
+
+gridAutoColumns = Proxy :: Proxy "grid-auto-columns"
+
+instance Property "grid-auto-columns"
+
+instance declarationGridAutoColumnsLengthPercentage ::
+  LengthPercentageTag t =>
+  Declaration "grid-auto-columns" (Measure t) where
+  pval = const val
+
+instance declarationGridAutoColumnsFlex :: Declaration "grid-auto-columns" Flex where
+  pval = const val
+
+instance declarationGridAutoColumnsTrackBreadthKeyword ::
+  ( IsSymbol s
+  , TrackBreadthKeyword s
+  ) =>
+  Declaration "grid-auto-columns" (Proxy s) where
+  pval = const val
+
+instance declarationGridAutoColumnsMinmax ::
+  TrackCompat Track compat' compat =>
+  Declaration "grid-auto-columns" (Minmax' compat') where
+  pval = const val
+
+instance declarationGridAutioColumnsFitContent ::
+  Declaration "grid-auto-columns" FitContent where
+  pval = const val
+
+instance declarationGridAutoColumnsList ::
+  ( Declaration "grid-auto-columns" x
+  , Declaration "grid-auto-columns" xs
+  ) =>
+  Declaration "grid-auto-columns" (x /\ xs) where
+  pval p' (x /\ xs) = pval p' x <> val " " <> pval p' xs
+
+-- https://www.w3.org/TR/css-grid-1/#propdef-grid-auto-rows
+
+gridAutoRows = Proxy :: Proxy "grid-auto-rows"
+
+instance Property "grid-auto-rows"
+
+instance declarationGridAutoRowsGridAutoColumns ::
+  Declaration "grid-auto-columns" v =>
+  Declaration "grid-auto-rows" v where
+  pval = const $ pval (Proxy :: Proxy "grid-auto-columns")
 
 --------------------------------------------------------------------------------
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -1,6 +1,5 @@
 module Tecton.Internal
-  ( class AlignContentKeyword
-  , class AlignmentBaselineKeyword
+  ( class AlignmentBaselineKeyword
   , class AlignmentBaselineOrBaselineShiftKeyword
   , class AllPropertiesAnimatable
   , class AngleTag
@@ -1332,6 +1331,14 @@ spaceBetween = Proxy :: Proxy "space-between"
 spaceEvenly = Proxy :: Proxy "space-evenly"
 stretch = Proxy :: Proxy "stretch"
 
+safe = Proxy :: Proxy "safe"
+unsafe = Proxy :: Proxy "unsafe"
+
+class OverflowPositionKeyword (s :: Symbol)
+
+instance OverflowPositionKeyword "safe"
+instance OverflowPositionKeyword "unsafe"
+
 class ContentPositionKeyword (s :: Symbol)
 
 instance ContentPositionKeyword "center"
@@ -1398,6 +1405,60 @@ else instance declarationJustifyContentContentPositionKeyword ::
   Declaration "justify-content" (Proxy s) where
   pval = const val
 
+-- https://www.w3.org/TR/css-align-3/#propdef-align-content
+
+alignContent = Proxy :: Proxy "align-content"
+
+instance Property "align-content"
+
+instance declarationAlignContentFirstBaseline ::
+  Declaration "align-content" (Proxy "first" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignContentLastBaseline ::
+  Declaration "align-content" (Proxy "last" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignContentOverflowPositionKeywordContentPositionKeyword ::
+  ( OverflowPositionKeyword sa
+  , IsSymbol sa
+  , ContentPositionKeyword sb
+  , IsSymbol sb
+  ) =>
+  Declaration "align-content" (Proxy sa ~ Proxy sb) where
+  pval = const val
+
+instance declarationAlignContentNormal ::
+  Declaration "align-content" (Proxy "normal") where
+  pval = const val
+
+else instance declarationAlignContentBaseline ::
+  Declaration "align-content" (Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignContentSpaceBetween ::
+  Declaration "align-content" (Proxy "space-between") where
+  pval = const val
+
+else instance declarationAlignContentSpaceAround ::
+  Declaration "align-content" (Proxy "space-around") where
+  pval = const val
+
+else instance declarationAlignContentSpaceEvenly ::
+  Declaration "align-content" (Proxy "space-evenly") where
+  pval = const val
+
+else instance declarationAlignContentStretch ::
+  Declaration "align-content" (Proxy "stretch") where
+  pval = const val
+
+else instance declarationAlignContentContentPositionKeyword ::
+  ( ContentPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-content" (Proxy s) where
+  pval = const val
+
 -- https://www.w3.org/TR/css-align-3/#propdef-justify-self
 
 justifySelf = Proxy :: Proxy "justify-self"
@@ -1421,14 +1482,6 @@ instance SelfPositionKeyword "self-start"
 instance SelfPositionKeyword "self-end"
 instance SelfPositionKeyword "flex-start"
 instance SelfPositionKeyword "flex-end"
-
-safe = Proxy :: Proxy "safe"
-unsafe = Proxy :: Proxy "unsafe"
-
-class OverflowPositionKeyword (s :: Symbol)
-
-instance OverflowPositionKeyword "safe"
-instance OverflowPositionKeyword "unsafe"
 
 instance declarationJustifySelfFirstBaseline ::
   Declaration "justify-self" (Proxy "first" ~ Proxy "baseline") where
@@ -3431,28 +3484,6 @@ else instance declarationFlexBasisWidth ::
   Declaration "width" a =>
   Declaration "flex-basis" a where
   pval = const $ pval width
-
--- https://www.w3.org/TR/css-flexbox-1/#propdef-align-content
-
-alignContent = Proxy :: Proxy "align-content"
-
-instance Property "align-content"
-
-class AlignContentKeyword (s :: Symbol)
-
-instance AlignContentKeyword "flex-start"
-instance AlignContentKeyword "flex-end"
-instance AlignContentKeyword "center"
-instance AlignContentKeyword "space-between"
-instance AlignContentKeyword "space-around"
-instance AlignContentKeyword "stretch"
-
-instance declarationAlignContent ::
-  ( AlignContentKeyword s
-  , ToVal (Proxy s)
-  ) =>
-  Declaration "align-content" (Proxy s) where
-  pval = const val
 
 --------------------------------------------------------------------------------
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -362,6 +362,7 @@ module Tecton.Internal
   , default
   , defer
   , deg
+  , dense
   , descendant
   , details
   , devanagari
@@ -450,6 +451,7 @@ module Tecton.Internal
   , georgian
   , grid
   , gridAutoColumns
+  , gridAutoFlow
   , gridAutoRows
   , gridTemplateColumns
   , gridTemplateRows
@@ -3856,6 +3858,34 @@ instance declarationGridAutoRowsGridAutoColumns ::
   Declaration "grid-auto-columns" v =>
   Declaration "grid-auto-rows" v where
   pval = const $ pval (Proxy :: Proxy "grid-auto-columns")
+
+-- https://www.w3.org/TR/css-grid-1/#propdef-grid-auto-flow
+
+gridAutoFlow = Proxy :: Proxy "grid-auto-flow"
+
+instance Property "grid-auto-flow"
+
+dense = Proxy :: Proxy "dense"
+
+instance declarationGridAutoFlowRow ::
+  Declaration "grid-auto-flow" (Proxy "row") where
+  pval = const val
+
+instance declarationGridAutoFlowColumn ::
+  Declaration "grid-auto-flow" (Proxy "column") where
+  pval = const val
+
+instance declarationGridAutoFlowDense ::
+  Declaration "grid-auto-flow" (Proxy "dense") where
+  pval = const val
+
+instance declarationGridAutoFlowRowDense ::
+  Declaration "grid-auto-flow" (Proxy "row" ~ Proxy "dense") where
+  pval = const val
+
+instance declarationGridAutoFlowColumnDense ::
+  Declaration "grid-auto-flow" (Proxy "column" ~ Proxy "dense") where
+  pval = const val
 
 --------------------------------------------------------------------------------
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -518,6 +518,7 @@ module Tecton.Internal
   , justify
   , justifyAll
   , justifyContent
+  , justifyItems
   , justifySelf
   , kannada
   , katakana
@@ -537,6 +538,7 @@ module Tecton.Internal
   , lastChild
   , lastOfType
   , left
+  , legacy
   , legend
   , letterSpacing
   , li
@@ -1404,6 +1406,88 @@ else instance declarationJustifySelfSelfPositionKeyword ::
   , IsSymbol s
   ) =>
   Declaration "justify-self" (Proxy s) where
+  pval = const val
+
+-- https://www.w3.org/TR/css-align-3/#propdef-justify-items
+
+justifyItems = Proxy :: Proxy "justify-items"
+
+instance Property "justify-items"
+
+legacy = Proxy :: Proxy "legacy"
+
+instance declarationJustifyItemsFirstBaseline ::
+  Declaration "justify-items" (Proxy "first" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationJustifyItemsLastBaseline ::
+  Declaration "justify-items" (Proxy "last" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationJustifyItemsLegacyLeft ::
+  Declaration "justify-items" (Proxy "legacy" ~ Proxy "left") where
+  pval = const val
+
+else instance declarationJustifyItemsLegacyRight ::
+  Declaration "justify-items" (Proxy "legacy" ~ Proxy "right") where
+  pval = const val
+
+else instance declarationJustifyItemsLegacyCenter ::
+  Declaration "justify-items" (Proxy "legacy" ~ Proxy "center") where
+  pval = const val
+
+else instance declarationJustifyItemsOverflowPositionKeywordLeft ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-items" (Proxy s ~ Proxy "left") where
+  pval = const val
+
+else instance declarationJustifyItemsOverflowPositionKeywordRight ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-items" (Proxy s ~ Proxy "right") where
+  pval = const val
+
+else instance declarationJustifyItemsOverflowPositionKeywordSelfPositionKeyword ::
+  ( OverflowPositionKeyword sa
+  , IsSymbol sa
+  , SelfPositionKeyword sb
+  , IsSymbol sb
+  ) =>
+  Declaration "justify-items" (Proxy sa ~ Proxy sb) where
+  pval = const val
+
+else instance declarationJustifyItemsNormal ::
+  Declaration "justify-items" (Proxy "normal") where
+  pval = const val
+
+else instance declarationJustifyItemsStretch ::
+  Declaration "justify-items" (Proxy "stretch") where
+  pval = const val
+
+else instance declarationJustifyItemsBaseline ::
+  Declaration "justify-items" (Proxy "baseline") where
+  pval = const val
+
+else instance declarationJustifyItemsLeft ::
+  Declaration "justify-items" (Proxy "left") where
+  pval = const val
+
+else instance declarationJustifyItemsRight ::
+  Declaration "justify-items" (Proxy "right") where
+  pval = const val
+
+else instance declarationJustifyItemsLegacy ::
+  Declaration "justify-items" (Proxy "legacy") where
+  pval = const val
+
+else instance declarationJustifyItemsSelfPositionKeyword ::
+  ( SelfPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-items" (Proxy s) where
   pval = const val
 
 -- https://www.w3.org/TR/css-align-3/#propdef-row-gap

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -21,6 +21,7 @@ module Tecton.Internal
   , class CollectMediaFeatures
   , class Combine
   , class ContentKeyword
+  , class ContentPositionKeyword
   , class CounterStyleKeyword
   , class Declaration
   , class DirectionKeyword
@@ -109,7 +110,6 @@ module Tecton.Internal
   , class IsVerticalAlign
   , class IsWidth
   , class IsWordSpacing
-  , class JustifyContentKeyword
   , class LengthPercentageTag
   , class LengthTag
   , class LineStyleKeyword
@@ -813,6 +813,7 @@ module Tecton.Internal
   , space
   , spaceAround
   , spaceBetween
+  , spaceEvenly
   , span
   , spellcheck
   , square
@@ -1318,18 +1319,98 @@ renderSheet config =
 -- Box Alignment
 -- https://www.w3.org/TR/css-align-3/
 
+-- https://www.w3.org/TR/css-align-3/#propdef-justify-content
+
+justifyContent = Proxy :: Proxy "justify-content"
+
+instance Property "justify-content"
+
+normal = Proxy :: Proxy "normal"
+
+spaceAround = Proxy :: Proxy "space-around"
+spaceBetween = Proxy :: Proxy "space-between"
+spaceEvenly = Proxy :: Proxy "space-evenly"
+stretch = Proxy :: Proxy "stretch"
+
+class ContentPositionKeyword (s :: Symbol)
+
+instance ContentPositionKeyword "center"
+instance ContentPositionKeyword "start"
+instance ContentPositionKeyword "end"
+instance ContentPositionKeyword "flex-start"
+instance ContentPositionKeyword "flex-end"
+
+instance declarationJustifyContentOverflowPositionKeywordLeft ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-content" (Proxy s ~ Proxy "left") where
+  pval = const val
+
+else instance declarationJustifyContentOverflowPositionKeywordRight ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-content" (Proxy s ~ Proxy "right") where
+  pval = const val
+
+else instance declarationJustifyContentOverflowPositionKeywordContentPositionKeyword ::
+  ( OverflowPositionKeyword sa
+  , IsSymbol sa
+  , ContentPositionKeyword sb
+  , IsSymbol sb
+  ) =>
+  Declaration "justify-content" (Proxy sa ~ Proxy sb) where
+  pval = const val
+
+instance declarationJustifyContentNormal ::
+  Declaration "justify-content" (Proxy "normal") where
+  pval = const val
+
+else instance declarationJustifyContentSpaceBetween ::
+  Declaration "justify-content" (Proxy "space-between") where
+  pval = const val
+
+else instance declarationJustifyContentSpaceAround ::
+  Declaration "justify-content" (Proxy "space-around") where
+  pval = const val
+
+else instance declarationJustifyContentSpaceEvenly ::
+  Declaration "justify-content" (Proxy "space-evenly") where
+  pval = const val
+
+else instance declarationJustifyContentStretch ::
+  Declaration "justify-content" (Proxy "stretch") where
+  pval = const val
+
+else instance declarationJustifyContentLeft ::
+  Declaration "justify-content" (Proxy "left") where
+  pval = const val
+
+else instance declarationJustifyContentRight ::
+  Declaration "justify-content" (Proxy "right") where
+  pval = const val
+
+else instance declarationJustifyContentContentPositionKeyword ::
+  ( ContentPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "justify-content" (Proxy s) where
+  pval = const val
+
 -- https://www.w3.org/TR/css-align-3/#propdef-justify-self
 
 justifySelf = Proxy :: Proxy "justify-self"
 
 instance Property "justify-self"
 
-stretch = Proxy :: Proxy "stretch"
-
 baseline = Proxy :: Proxy "baseline"
 
+center = Proxy :: Proxy "center"
 selfStart = Proxy :: Proxy "self-start"
 selfEnd = Proxy :: Proxy "self-end"
+flexStart = Proxy :: Proxy "flex-start"
+flexEnd = Proxy :: Proxy "flex-end"
 
 class SelfPositionKeyword (s :: Symbol)
 
@@ -1613,8 +1694,6 @@ rowGap = Proxy :: Proxy "row-gap"
 
 instance Property "row-gap"
 instance Animatable "row-gap"
-
-normal = Proxy :: Proxy "normal"
 
 instance declarationRowGapNormal :: Declaration "row-gap" (Proxy "normal") where
   pval = const val
@@ -3352,33 +3431,6 @@ else instance declarationFlexBasisWidth ::
   Declaration "width" a =>
   Declaration "flex-basis" a where
   pval = const $ pval width
-
--- https://www.w3.org/TR/css-flexbox-1/#propdef-justify-content
-
-justifyContent = Proxy :: Proxy "justify-content"
-
-instance Property "justify-content"
-
-flexStart = Proxy :: Proxy "flex-start"
-flexEnd = Proxy :: Proxy "flex-end"
-center = Proxy :: Proxy "center"
-spaceBetween = Proxy :: Proxy "space-between"
-spaceAround = Proxy :: Proxy "space-around"
-
-class JustifyContentKeyword (s :: Symbol)
-
-instance JustifyContentKeyword "flex-start"
-instance JustifyContentKeyword "flex-end"
-instance JustifyContentKeyword "center"
-instance JustifyContentKeyword "space-between"
-instance JustifyContentKeyword "space-around"
-
-instance declarationJustifyContent ::
-  ( JustifyContentKeyword s
-  , ToVal (Proxy s)
-  ) =>
-  Declaration "justify-content" (Proxy s) where
-  pval = const val
 
 -- https://www.w3.org/TR/css-flexbox-1/#propdef-align-content
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -1,7 +1,6 @@
 module Tecton.Internal
   ( class AlignContentKeyword
   , class AlignItemsKeyword
-  , class AlignSelfKeyword
   , class AlignmentBaselineKeyword
   , class AlignmentBaselineOrBaselineShiftKeyword
   , class AllPropertiesAnimatable
@@ -1406,6 +1405,65 @@ else instance declarationJustifySelfSelfPositionKeyword ::
   , IsSymbol s
   ) =>
   Declaration "justify-self" (Proxy s) where
+  pval = const val
+
+-- https://www.w3.org/TR/css-flexbox-1/#propdef-align-self
+
+alignSelf = Proxy :: Proxy "align-self"
+
+instance Property "align-self"
+
+instance declarationAlignSelfFirstBaseline ::
+  Declaration "align-self" (Proxy "first" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignSelfLastBaseline ::
+  Declaration "align-self" (Proxy "last" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignSelfOverflowPositionKeywordLeft ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-self" (Proxy s ~ Proxy "left") where
+  pval = const val
+
+else instance declarationAlignSelfOverflowPositionKeywordRight ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-self" (Proxy s ~ Proxy "right") where
+  pval = const val
+
+else instance declarationAlignSelfOverflowPositionKeywordSelfPositionKeyword ::
+  ( OverflowPositionKeyword sa
+  , IsSymbol sa
+  , SelfPositionKeyword sb
+  , IsSymbol sb
+  ) =>
+  Declaration "align-self" (Proxy sa ~ Proxy sb) where
+  pval = const val
+
+instance declarationAlignSelfAuto :: Declaration "align-self" (Proxy "auto") where
+  pval = const val
+
+else instance declarationAlignSelfNormal ::
+  Declaration "align-self" (Proxy "normal") where
+  pval = const val
+
+else instance declarationAlignSelfStretch ::
+  Declaration "align-self" (Proxy "stretch") where
+  pval = const val
+
+else instance declarationAlignSelfBaseline ::
+  Declaration "align-self" (Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignSelfSelfPositionKeyword ::
+  ( SelfPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-self" (Proxy s) where
   pval = const val
 
 -- https://www.w3.org/TR/css-align-3/#propdef-justify-items
@@ -3285,28 +3343,6 @@ instance declarationAlignItems ::
   , ToVal (Proxy s)
   ) =>
   Declaration "align-items" (Proxy s) where
-  pval = const val
-
--- https://www.w3.org/TR/css-flexbox-1/#propdef-align-self
-
-alignSelf = Proxy :: Proxy "align-self"
-
-instance Property "align-self"
-
-class AlignSelfKeyword (s :: Symbol)
-
-instance AlignSelfKeyword "auto"
-instance AlignSelfKeyword "flex-start"
-instance AlignSelfKeyword "flex-end"
-instance AlignSelfKeyword "center"
-instance AlignSelfKeyword "baseline"
-instance AlignSelfKeyword "stretch"
-
-instance declarationAlignSelf ::
-  ( AlignSelfKeyword s
-  , ToVal (Proxy s)
-  ) =>
-  Declaration "align-self" (Proxy s) where
   pval = const val
 
 -- https://www.w3.org/TR/css-flexbox-1/#propdef-align-content

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -453,6 +453,9 @@ module Tecton.Internal
   , gridAutoColumns
   , gridAutoFlow
   , gridAutoRows
+  , gridColumnEnd
+  , gridColumnStart
+  , gridRowEnd
   , gridRowStart
   , gridTemplateColumns
   , gridTemplateRows
@@ -3937,6 +3940,39 @@ instance declarationGridRowStartSpanLineName ::
 instance declarationGridRowStartSpanIntLineName ::
   Declaration "grid-row-start" (Proxy "span" ~ Int ~ LineName) where
   pval = const val
+
+-- https://www.w3.org/TR/css-grid-1/#propdef-grid-column-start
+
+gridColumnStart = Proxy :: Proxy "grid-column-start"
+
+instance Property "grid-column-start"
+
+instance declarationGridColumnStartGridRowStart ::
+  Declaration "grid-row-start" a =>
+  Declaration "grid-column-start" a where
+  pval = const $ pval (Proxy :: Proxy "grid-row-start")
+
+-- https://www.w3.org/TR/css-grid-1/#propdef-grid-row-end
+
+gridRowEnd = Proxy :: Proxy "grid-row-end"
+
+instance Property "grid-row-end"
+
+instance declarationGridRowEndGridRowStart ::
+  Declaration "grid-row-start" a =>
+  Declaration "grid-row-end" a where
+  pval = const $ pval (Proxy :: Proxy "grid-row-start")
+
+-- https://www.w3.org/TR/css-grid-1/#propdef-grid-column-end
+
+gridColumnEnd = Proxy :: Proxy "grid-column-end"
+
+instance Property "grid-column-end"
+
+instance declarationGridColumnEndGridRowStart ::
+  Declaration "grid-row-start" a =>
+  Declaration "grid-column-end" a where
+  pval = const $ pval (Proxy :: Proxy "grid-row-start")
 
 --------------------------------------------------------------------------------
 

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -1,6 +1,5 @@
 module Tecton.Internal
   ( class AlignContentKeyword
-  , class AlignItemsKeyword
   , class AlignmentBaselineKeyword
   , class AlignmentBaselineOrBaselineShiftKeyword
   , class AllPropertiesAnimatable
@@ -1325,6 +1324,10 @@ justifySelf = Proxy :: Proxy "justify-self"
 
 instance Property "justify-self"
 
+stretch = Proxy :: Proxy "stretch"
+
+baseline = Proxy :: Proxy "baseline"
+
 selfStart = Proxy :: Proxy "self-start"
 selfEnd = Proxy :: Proxy "self-end"
 
@@ -1407,7 +1410,7 @@ else instance declarationJustifySelfSelfPositionKeyword ::
   Declaration "justify-self" (Proxy s) where
   pval = const val
 
--- https://www.w3.org/TR/css-flexbox-1/#propdef-align-self
+-- https://www.w3.org/TR/css-align-3/#propdef-align-self
 
 alignSelf = Proxy :: Proxy "align-self"
 
@@ -1546,6 +1549,62 @@ else instance declarationJustifyItemsSelfPositionKeyword ::
   , IsSymbol s
   ) =>
   Declaration "justify-items" (Proxy s) where
+  pval = const val
+
+-- https://www.w3.org/TR/css-align-3/#propdef-align-items
+
+alignItems = Proxy :: Proxy "align-items"
+
+instance Property "align-items"
+
+instance declarationAlignItemsFirstBaseline ::
+  Declaration "align-items" (Proxy "first" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignItemsLastBaseline ::
+  Declaration "align-items" (Proxy "last" ~ Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignItemsOverflowPositionKeywordLeft ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-items" (Proxy s ~ Proxy "left") where
+  pval = const val
+
+else instance declarationAlignItemsOverflowPositionKeywordRight ::
+  ( OverflowPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-items" (Proxy s ~ Proxy "right") where
+  pval = const val
+
+else instance declarationAlignItemsOverflowPositionKeywordSelfPositionKeyword ::
+  ( OverflowPositionKeyword sa
+  , IsSymbol sa
+  , SelfPositionKeyword sb
+  , IsSymbol sb
+  ) =>
+  Declaration "align-items" (Proxy sa ~ Proxy sb) where
+  pval = const val
+
+instance declarationAlignItemsNormal ::
+  Declaration "align-items" (Proxy "normal") where
+  pval = const val
+
+else instance declarationAlignItemsStretch ::
+  Declaration "align-items" (Proxy "stretch") where
+  pval = const val
+
+else instance declarationAlignItemsBaseline ::
+  Declaration "align-items" (Proxy "baseline") where
+  pval = const val
+
+else instance declarationAlignItemsSelfPositionKeyword ::
+  ( SelfPositionKeyword s
+  , IsSymbol s
+  ) =>
+  Declaration "align-items" (Proxy s) where
   pval = const val
 
 -- https://www.w3.org/TR/css-align-3/#propdef-row-gap
@@ -3319,30 +3378,6 @@ instance declarationJustifyContent ::
   , ToVal (Proxy s)
   ) =>
   Declaration "justify-content" (Proxy s) where
-  pval = const val
-
--- https://www.w3.org/TR/css-flexbox-1/#propdef-align-items
-
-alignItems = Proxy :: Proxy "align-items"
-
-instance Property "align-items"
-
-baseline = Proxy :: Proxy "baseline"
-stretch = Proxy :: Proxy "stretch"
-
-class AlignItemsKeyword (s :: Symbol)
-
-instance AlignItemsKeyword "flex-start"
-instance AlignItemsKeyword "flex-end"
-instance AlignItemsKeyword "center"
-instance AlignItemsKeyword "baseline"
-instance AlignItemsKeyword "stretch"
-
-instance declarationAlignItems ::
-  ( AlignItemsKeyword s
-  , ToVal (Proxy s)
-  ) =>
-  Declaration "align-items" (Proxy s) where
   pval = const val
 
 -- https://www.w3.org/TR/css-flexbox-1/#propdef-align-content

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -167,6 +167,78 @@ spec = do
         `isRenderedFrom`
         (justifySelf := unsafe ~ right)
 
+    describe "align-self property" do
+
+      "align-self:inherit" `isRenderedFrom` (alignSelf := inherit)
+
+      "align-self:initial" `isRenderedFrom` (alignSelf := initial)
+
+      "align-self:unset" `isRenderedFrom` (alignSelf := unset)
+
+      "align-self:auto" `isRenderedFrom` (alignSelf := auto)
+
+      "align-self:normal" `isRenderedFrom` (alignSelf := normal)
+
+      "align-self:stretch" `isRenderedFrom` (alignSelf := stretch)
+
+      "align-self:baseline" `isRenderedFrom` (alignSelf := baseline)
+
+      "align-self:first baseline"
+        `isRenderedFrom`
+        (alignSelf := first ~ baseline)
+
+      "align-self:last baseline" `isRenderedFrom` (alignSelf := last ~ baseline)
+
+      "align-self:center" `isRenderedFrom` (alignSelf := center)
+
+      "align-self:start" `isRenderedFrom` (alignSelf := start)
+
+      "align-self:end" `isRenderedFrom` (alignSelf := end)
+
+      "align-self:self-start" `isRenderedFrom` (alignSelf := selfStart)
+
+      "align-self:self-end" `isRenderedFrom` (alignSelf :=  selfEnd)
+
+      "align-self:flex-start" `isRenderedFrom` (alignSelf :=  flexStart)
+
+      "align-self:flex-end" `isRenderedFrom` (alignSelf := flexEnd)
+
+      "align-self:safe center" `isRenderedFrom` (alignSelf := safe ~ center)
+
+      "align-self:safe start" `isRenderedFrom` (alignSelf := safe ~ start)
+
+      "align-self:safe end" `isRenderedFrom` (alignSelf := safe ~ end)
+
+      "align-self:safe self-start"
+        `isRenderedFrom`
+        (alignSelf := safe ~ selfStart)
+
+      "align-self:safe self-end" `isRenderedFrom` (alignSelf := safe ~ selfEnd)
+
+      "align-self:safe flex-start"
+        `isRenderedFrom`
+        (alignSelf := safe ~ flexStart)
+
+      "align-self:unsafe flex-end" `isRenderedFrom` (alignSelf := unsafe ~ flexEnd)
+
+      "align-self:unsafe center" `isRenderedFrom` (alignSelf := unsafe ~ center)
+
+      "align-self:unsafe start" `isRenderedFrom` (alignSelf := unsafe ~ start)
+
+      "align-self:unsafe end" `isRenderedFrom` (alignSelf := unsafe ~ end)
+
+      "align-self:unsafe self-start"
+        `isRenderedFrom`
+        (alignSelf := unsafe ~ selfStart)
+
+      "align-self:unsafe self-end" `isRenderedFrom` (alignSelf := unsafe ~ selfEnd)
+
+      "align-self:unsafe flex-start"
+        `isRenderedFrom`
+        (alignSelf := unsafe ~ flexStart)
+
+      "align-self:unsafe flex-end" `isRenderedFrom` (alignSelf := unsafe ~ flexEnd)
+
     describe "justify-items property" do
 
       "justify-items:inherit" `isRenderedFrom` (justifyItems := inherit)
@@ -280,75 +352,3 @@ spec = do
       "justify-items:legacy center"
         `isRenderedFrom`
         (justifyItems := legacy ~ center)
-
-    describe "align-self property" do
-
-      "align-self:inherit" `isRenderedFrom` (alignSelf := inherit)
-
-      "align-self:initial" `isRenderedFrom` (alignSelf := initial)
-
-      "align-self:unset" `isRenderedFrom` (alignSelf := unset)
-
-      "align-self:auto" `isRenderedFrom` (alignSelf := auto)
-
-      "align-self:normal" `isRenderedFrom` (alignSelf := normal)
-
-      "align-self:stretch" `isRenderedFrom` (alignSelf := stretch)
-
-      "align-self:baseline" `isRenderedFrom` (alignSelf := baseline)
-
-      "align-self:first baseline"
-        `isRenderedFrom`
-        (alignSelf := first ~ baseline)
-
-      "align-self:last baseline" `isRenderedFrom` (alignSelf := last ~ baseline)
-
-      "align-self:center" `isRenderedFrom` (alignSelf := center)
-
-      "align-self:start" `isRenderedFrom` (alignSelf := start)
-
-      "align-self:end" `isRenderedFrom` (alignSelf := end)
-
-      "align-self:self-start" `isRenderedFrom` (alignSelf := selfStart)
-
-      "align-self:self-end" `isRenderedFrom` (alignSelf :=  selfEnd)
-
-      "align-self:flex-start" `isRenderedFrom` (alignSelf :=  flexStart)
-
-      "align-self:flex-end" `isRenderedFrom` (alignSelf := flexEnd)
-
-      "align-self:safe center" `isRenderedFrom` (alignSelf := safe ~ center)
-
-      "align-self:safe start" `isRenderedFrom` (alignSelf := safe ~ start)
-
-      "align-self:safe end" `isRenderedFrom` (alignSelf := safe ~ end)
-
-      "align-self:safe self-start"
-        `isRenderedFrom`
-        (alignSelf := safe ~ selfStart)
-
-      "align-self:safe self-end" `isRenderedFrom` (alignSelf := safe ~ selfEnd)
-
-      "align-self:safe flex-start"
-        `isRenderedFrom`
-        (alignSelf := safe ~ flexStart)
-
-      "align-self:unsafe flex-end" `isRenderedFrom` (alignSelf := unsafe ~ flexEnd)
-
-      "align-self:unsafe center" `isRenderedFrom` (alignSelf := unsafe ~ center)
-
-      "align-self:unsafe start" `isRenderedFrom` (alignSelf := unsafe ~ start)
-
-      "align-self:unsafe end" `isRenderedFrom` (alignSelf := unsafe ~ end)
-
-      "align-self:unsafe self-start"
-        `isRenderedFrom`
-        (alignSelf := unsafe ~ selfStart)
-
-      "align-self:unsafe self-end" `isRenderedFrom` (alignSelf := unsafe ~ selfEnd)
-
-      "align-self:unsafe flex-start"
-        `isRenderedFrom`
-        (alignSelf := unsafe ~ flexStart)
-
-      "align-self:unsafe flex-end" `isRenderedFrom` (alignSelf := unsafe ~ flexEnd)

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -4,7 +4,7 @@ module Test.AlignSpec where
 
 import Prelude
 
-import Tecton (auto, baseline, center, columnGap, end, first, flexEnd, flexStart, inherit, gap, initial, justifySelf, last, left, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
+import Tecton (auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -166,3 +166,117 @@ spec = do
       "justify-self:unsafe right"
         `isRenderedFrom`
         (justifySelf := unsafe ~ right)
+
+    describe "justify-items property" do
+
+      "justify-items:inherit" `isRenderedFrom` (justifyItems := inherit)
+
+      "justify-items:initial" `isRenderedFrom` (justifyItems := initial)
+
+      "justify-items:unset" `isRenderedFrom` (justifyItems := unset)
+
+      "justify-items:normal" `isRenderedFrom` (justifyItems := normal)
+
+      "justify-items:stretch" `isRenderedFrom` (justifyItems := stretch)
+
+      "justify-items:baseline" `isRenderedFrom` (justifyItems := baseline)
+
+      "justify-items:first baseline"
+        `isRenderedFrom`
+        (justifyItems := first ~ baseline)
+
+      "justify-items:last baseline"
+        `isRenderedFrom`
+        (justifyItems := last ~ baseline)
+
+      "justify-items:center" `isRenderedFrom` (justifyItems := center)
+
+      "justify-items:start" `isRenderedFrom` (justifyItems := start)
+
+      "justify-items:end" `isRenderedFrom` (justifyItems := end)
+
+      "justify-items:self-start" `isRenderedFrom` (justifyItems := selfStart)
+
+      "justify-items:self-end" `isRenderedFrom` (justifyItems := selfEnd)
+
+      "justify-items:flex-start" `isRenderedFrom` (justifyItems := flexStart)
+
+      "justify-items:flex-end" `isRenderedFrom` (justifyItems := flexEnd)
+
+      "justify-items:left" `isRenderedFrom` (justifyItems := left)
+
+      "justify-items:right" `isRenderedFrom` (justifyItems := right)
+
+      "justify-items:safe center"
+        `isRenderedFrom`
+        (justifyItems := safe ~ center)
+
+      "justify-items:safe start" `isRenderedFrom` (justifyItems := safe ~ start)
+
+      "justify-items:safe end" `isRenderedFrom` (justifyItems := safe ~ end)
+
+      "justify-items:safe self-start"
+        `isRenderedFrom`
+        (justifyItems := safe ~ selfStart)
+
+      "justify-items:safe self-end"
+        `isRenderedFrom`
+        (justifyItems := safe ~ selfEnd)
+
+      "justify-items:safe flex-start"
+        `isRenderedFrom`
+        (justifyItems := safe ~ flexStart)
+
+      "justify-items:safe flex-end"
+        `isRenderedFrom`
+        (justifyItems := safe ~ flexEnd)
+
+      "justify-items:safe left" `isRenderedFrom` (justifyItems := safe ~ left)
+
+      "justify-items:safe right" `isRenderedFrom` (justifyItems := safe ~ right)
+
+      "justify-items:unsafe center"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ center)
+
+      "justify-items:unsafe start"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ start)
+
+      "justify-items:unsafe end" `isRenderedFrom` (justifyItems := unsafe ~ end)
+
+      "justify-items:unsafe self-start"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ selfStart)
+
+      "justify-items:unsafe self-end"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ selfEnd)
+
+      "justify-items:unsafe flex-start"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ flexStart)
+
+      "justify-items:unsafe flex-end"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ flexEnd)
+
+      "justify-items:unsafe left" `isRenderedFrom` (justifyItems := unsafe ~ left)
+
+      "justify-items:unsafe right"
+        `isRenderedFrom`
+        (justifyItems := unsafe ~ right)
+
+      "justify-items:legacy" `isRenderedFrom` (justifyItems := legacy)
+
+      "justify-items:legacy left"
+        `isRenderedFrom`
+        (justifyItems := legacy ~ left)
+
+      "justify-items:legacy right"
+        `isRenderedFrom`
+        (justifyItems := legacy ~ right)
+
+      "justify-items:legacy center"
+        `isRenderedFrom`
+        (justifyItems := legacy ~ center)

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -4,7 +4,7 @@ module Test.AlignSpec where
 
 import Prelude
 
-import Tecton (columnGap, inherit, gap, initial, normal, pct, px, rowGap, unset, (:=), (~))
+import Tecton (auto, baseline, center, columnGap, end, first, flexEnd, flexStart, inherit, gap, initial, justifySelf, last, left, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -66,3 +66,103 @@ spec = do
       "gap:1px normal" `isRenderedFrom` (gap := px 1 ~ normal)
 
       "gap:10% normal" `isRenderedFrom` (gap := pct 10 ~ normal)
+
+    describe "justify-self property" do
+
+      "justify-self:inherit" `isRenderedFrom` (justifySelf := inherit)
+
+      "justify-self:initial" `isRenderedFrom` (justifySelf := initial)
+
+      "justify-self:unset" `isRenderedFrom` (justifySelf := unset)
+
+      "justify-self:auto" `isRenderedFrom` (justifySelf := auto)
+
+      "justify-self:normal" `isRenderedFrom` (justifySelf := normal)
+
+      "justify-self:stretch" `isRenderedFrom` (justifySelf := stretch)
+
+      "justify-self:baseline" `isRenderedFrom` (justifySelf := baseline)
+
+      "justify-self:first baseline"
+        `isRenderedFrom`
+        (justifySelf := first ~ baseline)
+
+      "justify-self:last baseline"
+        `isRenderedFrom`
+        (justifySelf := last ~ baseline)
+
+      "justify-self:center" `isRenderedFrom` (justifySelf := center)
+
+      "justify-self:start" `isRenderedFrom` (justifySelf := start)
+
+      "justify-self:end" `isRenderedFrom` (justifySelf := end)
+
+      "justify-self:self-start" `isRenderedFrom` (justifySelf := selfStart)
+
+      "justify-self:self-end" `isRenderedFrom` (justifySelf := selfEnd)
+
+      "justify-self:flex-start" `isRenderedFrom` (justifySelf := flexStart)
+
+      "justify-self:flex-end" `isRenderedFrom` (justifySelf := flexEnd)
+
+      "justify-self:left" `isRenderedFrom` (justifySelf := left)
+
+      "justify-self:right" `isRenderedFrom` (justifySelf := right)
+
+      "justify-self:safe center" `isRenderedFrom` (justifySelf := safe ~ center)
+
+      "justify-self:safe start" `isRenderedFrom` (justifySelf := safe ~ start)
+
+      "justify-self:safe end" `isRenderedFrom` (justifySelf := safe ~ end)
+
+      "justify-self:safe self-start"
+        `isRenderedFrom`
+        (justifySelf := safe ~ selfStart)
+
+      "justify-self:safe self-end"
+        `isRenderedFrom`
+        (justifySelf := safe ~ selfEnd)
+
+      "justify-self:safe flex-start"
+        `isRenderedFrom`
+        (justifySelf := safe ~ flexStart)
+
+      "justify-self:safe flex-end"
+        `isRenderedFrom`
+        (justifySelf := safe ~ flexEnd)
+
+      "justify-self:safe left" `isRenderedFrom` (justifySelf := safe ~ left)
+
+      "justify-self:safe right" `isRenderedFrom` (justifySelf := safe ~ right)
+
+      "justify-self:unsafe center"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ center)
+
+      "justify-self:unsafe start"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ start)
+
+      "justify-self:unsafe end" `isRenderedFrom` (justifySelf := unsafe ~ end)
+
+      "justify-self:unsafe self-start"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ selfStart)
+
+      "justify-self:unsafe self-end"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ selfEnd)
+
+      "justify-self:unsafe flex-start"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ flexStart)
+
+      "justify-self:unsafe flex-end"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ flexEnd)
+
+      "justify-self:unsafe left" `isRenderedFrom` (justifySelf := unsafe ~ left)
+
+      "justify-self:unsafe right"
+        `isRenderedFrom`
+        (justifySelf := unsafe ~ right)

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -4,7 +4,7 @@ module Test.AlignSpec where
 
 import Prelude
 
-import Tecton (auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
+import Tecton (alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -280,3 +280,75 @@ spec = do
       "justify-items:legacy center"
         `isRenderedFrom`
         (justifyItems := legacy ~ center)
+
+    describe "align-self property" do
+
+      "align-self:inherit" `isRenderedFrom` (alignSelf := inherit)
+
+      "align-self:initial" `isRenderedFrom` (alignSelf := initial)
+
+      "align-self:unset" `isRenderedFrom` (alignSelf := unset)
+
+      "align-self:auto" `isRenderedFrom` (alignSelf := auto)
+
+      "align-self:normal" `isRenderedFrom` (alignSelf := normal)
+
+      "align-self:stretch" `isRenderedFrom` (alignSelf := stretch)
+
+      "align-self:baseline" `isRenderedFrom` (alignSelf := baseline)
+
+      "align-self:first baseline"
+        `isRenderedFrom`
+        (alignSelf := first ~ baseline)
+
+      "align-self:last baseline" `isRenderedFrom` (alignSelf := last ~ baseline)
+
+      "align-self:center" `isRenderedFrom` (alignSelf := center)
+
+      "align-self:start" `isRenderedFrom` (alignSelf := start)
+
+      "align-self:end" `isRenderedFrom` (alignSelf := end)
+
+      "align-self:self-start" `isRenderedFrom` (alignSelf := selfStart)
+
+      "align-self:self-end" `isRenderedFrom` (alignSelf :=  selfEnd)
+
+      "align-self:flex-start" `isRenderedFrom` (alignSelf :=  flexStart)
+
+      "align-self:flex-end" `isRenderedFrom` (alignSelf := flexEnd)
+
+      "align-self:safe center" `isRenderedFrom` (alignSelf := safe ~ center)
+
+      "align-self:safe start" `isRenderedFrom` (alignSelf := safe ~ start)
+
+      "align-self:safe end" `isRenderedFrom` (alignSelf := safe ~ end)
+
+      "align-self:safe self-start"
+        `isRenderedFrom`
+        (alignSelf := safe ~ selfStart)
+
+      "align-self:safe self-end" `isRenderedFrom` (alignSelf := safe ~ selfEnd)
+
+      "align-self:safe flex-start"
+        `isRenderedFrom`
+        (alignSelf := safe ~ flexStart)
+
+      "align-self:unsafe flex-end" `isRenderedFrom` (alignSelf := unsafe ~ flexEnd)
+
+      "align-self:unsafe center" `isRenderedFrom` (alignSelf := unsafe ~ center)
+
+      "align-self:unsafe start" `isRenderedFrom` (alignSelf := unsafe ~ start)
+
+      "align-self:unsafe end" `isRenderedFrom` (alignSelf := unsafe ~ end)
+
+      "align-self:unsafe self-start"
+        `isRenderedFrom`
+        (alignSelf := unsafe ~ selfStart)
+
+      "align-self:unsafe self-end" `isRenderedFrom` (alignSelf := unsafe ~ selfEnd)
+
+      "align-self:unsafe flex-start"
+        `isRenderedFrom`
+        (alignSelf := unsafe ~ flexStart)
+
+      "align-self:unsafe flex-end" `isRenderedFrom` (alignSelf := unsafe ~ flexEnd)

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -4,7 +4,7 @@ module Test.AlignSpec where
 
 import Prelude
 
-import Tecton (alignItems, alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyContent, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, spaceAround, spaceBetween, spaceEvenly, start, stretch, unsafe, unset, (:=), (~))
+import Tecton (alignContent, alignItems, alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyContent, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, spaceAround, spaceBetween, spaceEvenly, start, stretch, unsafe, unset, (:=), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -106,6 +106,88 @@ spec = do
       "justify-content:unsafe right"
         `isRenderedFrom`
         (justifyContent := unsafe ~ right)
+
+    describe "align-content property" do
+
+      "align-content:inherit" `isRenderedFrom` (alignContent := inherit)
+
+      "align-content:initial" `isRenderedFrom` (alignContent := initial)
+
+      "align-content:unset" `isRenderedFrom` (alignContent := unset)
+
+      "align-content:normal" `isRenderedFrom` (alignContent := normal)
+
+      "align-content:baseline" `isRenderedFrom` (alignContent := baseline)
+
+      "align-content:first baseline"
+        `isRenderedFrom`
+        (alignContent := first ~ baseline)
+
+      "align-content:last baseline"
+        `isRenderedFrom`
+        (alignContent := last ~ baseline)
+
+      "align-content:space-between"
+        `isRenderedFrom`
+        (alignContent := spaceBetween)
+
+      "align-content:space-around"
+        `isRenderedFrom`
+        (alignContent := spaceAround)
+
+      "align-content:space-evenly"
+        `isRenderedFrom`
+        (alignContent := spaceEvenly)
+
+      "align-content:stretch" `isRenderedFrom` (alignContent := stretch)
+
+      "align-content:center" `isRenderedFrom` (alignContent := center)
+
+      "align-content:start" `isRenderedFrom` (alignContent := start)
+
+      "align-content:end" `isRenderedFrom` (alignContent := end)
+
+      "align-content:flex-start"
+        `isRenderedFrom`
+        (alignContent := flexStart)
+
+      "align-content:flex-end" `isRenderedFrom` (alignContent := flexEnd)
+ 
+      "align-content:safe center"
+        `isRenderedFrom`
+        (alignContent := safe ~ center)
+
+      "align-content:safe start"
+        `isRenderedFrom`
+        (alignContent := safe ~ start)
+
+      "align-content:safe end" `isRenderedFrom` (alignContent := safe ~ end)
+
+      "align-content:safe flex-start"
+        `isRenderedFrom`
+        (alignContent := safe ~ flexStart)
+
+      "align-content:safe flex-end"
+        `isRenderedFrom`
+        (alignContent := safe ~ flexEnd)
+ 
+      "align-content:unsafe center"
+        `isRenderedFrom`
+        (alignContent := unsafe ~ center)
+
+      "align-content:unsafe start"
+        `isRenderedFrom`
+        (alignContent := unsafe ~ start)
+
+      "align-content:unsafe end" `isRenderedFrom` (alignContent := unsafe ~ end)
+
+      "align-content:unsafe flex-start"
+        `isRenderedFrom`
+        (alignContent := unsafe ~ flexStart)
+
+      "align-content:unsafe flex-end"
+        `isRenderedFrom`
+        (alignContent := unsafe ~ flexEnd)
 
     describe "justify-self property" do
 

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -4,7 +4,7 @@ module Test.AlignSpec where
 
 import Prelude
 
-import Tecton (alignItems, alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
+import Tecton (alignItems, alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyContent, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, spaceAround, spaceBetween, spaceEvenly, start, stretch, unsafe, unset, (:=), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -15,57 +15,97 @@ spec = do
 
   describe "Box Alignment Module" do
 
-    describe "row-gap property" do
+    describe "justify-content property" do
 
-      "row-gap:inherit" `isRenderedFrom` (rowGap := inherit)
+      "justify-content:inherit" `isRenderedFrom` (justifyContent := inherit)
 
-      "row-gap:initial" `isRenderedFrom` (rowGap := initial)
+      "justify-content:initial" `isRenderedFrom` (justifyContent := initial)
 
-      "row-gap:unset" `isRenderedFrom` (rowGap := unset)
+      "justify-content:unset" `isRenderedFrom` (justifyContent := unset)
 
-      "row-gap:normal" `isRenderedFrom` (rowGap := normal)
+      "justify-content:normal" `isRenderedFrom` (justifyContent := normal)
 
-      "row-gap:4px" `isRenderedFrom` (rowGap := px 4)
+      "justify-content:space-between"
+        `isRenderedFrom`
+        (justifyContent := spaceBetween)
 
-      "row-gap:10%" `isRenderedFrom` (rowGap := pct 10)
+      "justify-content:space-around"
+        `isRenderedFrom`
+        (justifyContent := spaceAround)
 
-    describe "column-gap property" do
+      "justify-content:space-evenly"
+        `isRenderedFrom`
+        (justifyContent := spaceEvenly)
 
-      "column-gap:inherit" `isRenderedFrom` (columnGap := inherit)
+      "justify-content:stretch" `isRenderedFrom` (justifyContent := stretch)
+ 
+      "justify-content:center" `isRenderedFrom` (justifyContent := center)
 
-      "column-gap:initial" `isRenderedFrom` (columnGap := initial)
+      "justify-content:start" `isRenderedFrom` (justifyContent := start)
 
-      "column-gap:unset" `isRenderedFrom` (columnGap := unset)
+      "justify-content:end" `isRenderedFrom` (justifyContent := end)
 
-      "column-gap:normal" `isRenderedFrom` (columnGap := normal)
+      "justify-content:flex-start"
+        `isRenderedFrom`
+        (justifyContent := flexStart)
 
-      "column-gap:4px" `isRenderedFrom` (columnGap := px 4)
+      "justify-content:flex-end" `isRenderedFrom` (justifyContent := flexEnd)
 
-      "column-gap:10%" `isRenderedFrom` (columnGap := pct 10)
+      "justify-content:left" `isRenderedFrom` (justifyContent := left)
 
-    describe "gap property" do
+      "justify-content:right" `isRenderedFrom` (justifyContent := right)
+ 
+      "justify-content:safe center"
+        `isRenderedFrom`
+        (justifyContent := safe ~ center)
 
-      "gap:inherit" `isRenderedFrom` (gap := inherit)
+      "justify-content:safe start"
+        `isRenderedFrom`
+        (justifyContent := safe ~ start)
 
-      "gap:initial" `isRenderedFrom` (gap := initial)
+      "justify-content:safe end" `isRenderedFrom` (justifyContent := safe ~ end)
 
-      "gap:unset" `isRenderedFrom` (gap := unset)
+      "justify-content:safe flex-start"
+        `isRenderedFrom`
+        (justifyContent := safe ~ flexStart)
 
-      "gap:normal" `isRenderedFrom` (gap := normal)
+      "justify-content:safe flex-end"
+        `isRenderedFrom`
+        (justifyContent := safe ~ flexEnd)
 
-      "gap:10px" `isRenderedFrom` (gap := px 10)
+      "justify-content:safe left"
+        `isRenderedFrom`
+        (justifyContent := safe ~ left)
 
-      "gap:1%" `isRenderedFrom` (gap := pct 1)
+      "justify-content:safe right"
+        `isRenderedFrom`
+        (justifyContent := safe ~ right)
+ 
+      "justify-content:unsafe center"
+        `isRenderedFrom`
+        (justifyContent := unsafe ~ center)
 
-      "gap:normal normal" `isRenderedFrom` (gap := normal ~ normal)
+      "justify-content:unsafe start"
+        `isRenderedFrom`
+        (justifyContent := unsafe ~ start)
 
-      "gap:normal 1px" `isRenderedFrom` (gap := normal ~ px 1)
+      "justify-content:unsafe end" `isRenderedFrom` (justifyContent := unsafe ~ end)
 
-      "gap:normal 10%" `isRenderedFrom` (gap := normal ~ pct 10)
+      "justify-content:unsafe flex-start"
+        `isRenderedFrom`
+        (justifyContent := unsafe ~ flexStart)
 
-      "gap:1px normal" `isRenderedFrom` (gap := px 1 ~ normal)
+      "justify-content:unsafe flex-end"
+        `isRenderedFrom`
+        (justifyContent := unsafe ~ flexEnd)
 
-      "gap:10% normal" `isRenderedFrom` (gap := pct 10 ~ normal)
+      "justify-content:unsafe left"
+        `isRenderedFrom`
+        (justifyContent := unsafe ~ left)
+
+      "justify-content:unsafe right"
+        `isRenderedFrom`
+        (justifyContent := unsafe ~ right)
 
     describe "justify-self property" do
 
@@ -434,3 +474,55 @@ spec = do
       "align-items:unsafe flex-end"
         `isRenderedFrom`
         (alignItems := unsafe ~ flexEnd)
+
+    describe "row-gap property" do
+
+      "row-gap:inherit" `isRenderedFrom` (rowGap := inherit)
+
+      "row-gap:initial" `isRenderedFrom` (rowGap := initial)
+
+      "row-gap:unset" `isRenderedFrom` (rowGap := unset)
+
+      "row-gap:normal" `isRenderedFrom` (rowGap := normal)
+
+      "row-gap:4px" `isRenderedFrom` (rowGap := px 4)
+
+      "row-gap:10%" `isRenderedFrom` (rowGap := pct 10)
+
+    describe "column-gap property" do
+
+      "column-gap:inherit" `isRenderedFrom` (columnGap := inherit)
+
+      "column-gap:initial" `isRenderedFrom` (columnGap := initial)
+
+      "column-gap:unset" `isRenderedFrom` (columnGap := unset)
+
+      "column-gap:normal" `isRenderedFrom` (columnGap := normal)
+
+      "column-gap:4px" `isRenderedFrom` (columnGap := px 4)
+
+      "column-gap:10%" `isRenderedFrom` (columnGap := pct 10)
+
+    describe "gap property" do
+
+      "gap:inherit" `isRenderedFrom` (gap := inherit)
+
+      "gap:initial" `isRenderedFrom` (gap := initial)
+
+      "gap:unset" `isRenderedFrom` (gap := unset)
+
+      "gap:normal" `isRenderedFrom` (gap := normal)
+
+      "gap:10px" `isRenderedFrom` (gap := px 10)
+
+      "gap:1%" `isRenderedFrom` (gap := pct 1)
+
+      "gap:normal normal" `isRenderedFrom` (gap := normal ~ normal)
+
+      "gap:normal 1px" `isRenderedFrom` (gap := normal ~ px 1)
+
+      "gap:normal 10%" `isRenderedFrom` (gap := normal ~ pct 10)
+
+      "gap:1px normal" `isRenderedFrom` (gap := px 1 ~ normal)
+
+      "gap:10% normal" `isRenderedFrom` (gap := pct 10 ~ normal)

--- a/test/AlignSpec.purs
+++ b/test/AlignSpec.purs
@@ -4,7 +4,7 @@ module Test.AlignSpec where
 
 import Prelude
 
-import Tecton (alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
+import Tecton (alignItems, alignSelf, auto, baseline, center, columnGap, end, first, flexEnd, flexStart, gap, initial, inherit, justifyItems, justifySelf, last, left, legacy, normal, pct, px, right, rowGap, safe, selfEnd, selfStart, start, stretch, unsafe, unset, (:=), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -352,3 +352,85 @@ spec = do
       "justify-items:legacy center"
         `isRenderedFrom`
         (justifyItems := legacy ~ center)
+
+    describe "align-items property" do
+
+      "align-items:inherit" `isRenderedFrom` (alignItems := inherit)
+
+      "align-items:initial" `isRenderedFrom` (alignItems := initial)
+
+      "align-items:unset" `isRenderedFrom` (alignItems := unset)
+
+      "align-items:normal" `isRenderedFrom` (alignItems := normal)
+
+      "align-items:stretch" `isRenderedFrom` (alignItems := stretch)
+
+      "align-items:baseline" `isRenderedFrom` (alignItems := baseline)
+
+      "align-items:first baseline"
+        `isRenderedFrom`
+        (alignItems := first ~ baseline)
+
+      "align-items:last baseline"
+        `isRenderedFrom`
+        (alignItems := last ~ baseline)
+
+      "align-items:center" `isRenderedFrom` (alignItems := center)
+
+      "align-items:start" `isRenderedFrom` (alignItems := start)
+
+      "align-items:end" `isRenderedFrom` (alignItems := end)
+
+      "align-items:self-start" `isRenderedFrom` (alignItems := selfStart)
+
+      "align-items:self-end" `isRenderedFrom` (alignItems := selfEnd)
+
+      "align-items:flex-start" `isRenderedFrom` (alignItems := flexStart)
+
+      "align-items:flex-end" `isRenderedFrom` (alignItems := flexEnd)
+
+      "align-items:safe center" `isRenderedFrom` (alignItems := safe ~ center)
+
+      "align-items:safe start" `isRenderedFrom` (alignItems := safe ~ start)
+
+      "align-items:safe end" `isRenderedFrom` (alignItems := safe ~ end)
+
+      "align-items:safe self-start"
+        `isRenderedFrom`
+        (alignItems := safe ~ selfStart)
+
+      "align-items:safe self-end"
+        `isRenderedFrom`
+        (alignItems := safe ~ selfEnd)
+
+      "align-items:safe flex-start"
+        `isRenderedFrom`
+        (alignItems := safe ~ flexStart)
+
+      "align-items:safe flex-end"
+        `isRenderedFrom`
+        (alignItems := safe ~ flexEnd)
+
+      "align-items:unsafe center"
+        `isRenderedFrom`
+        (alignItems := unsafe ~ center)
+
+      "align-items:unsafe start" `isRenderedFrom` (alignItems := unsafe ~ start)
+
+      "align-items:unsafe end" `isRenderedFrom` (alignItems := unsafe ~ end)
+
+      "align-items:unsafe self-start"
+        `isRenderedFrom`
+        (alignItems := unsafe ~ selfStart)
+
+      "align-items:unsafe self-end"
+        `isRenderedFrom`
+        (alignItems := unsafe ~ selfEnd)
+
+      "align-items:unsafe flex-start"
+        `isRenderedFrom`
+        (alignItems := unsafe ~ flexStart)
+
+      "align-items:unsafe flex-end"
+        `isRenderedFrom`
+        (alignItems := unsafe ~ flexEnd)

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -5,7 +5,7 @@ module Test.GridSpec where
 import Prelude
 
 import Data.Tuple.Nested ((/\))
-import Tecton (auto, autoFill, autoFit, em, fitContent, fr, gridAutoColumns, gridAutoRows, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, unset, vw, (:=), (@-@))
+import Tecton (auto, autoFill, autoFit, column, dense, em, fitContent, fr, gridAutoColumns, gridAutoFlow, gridAutoRows, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, row, unset, vw, (:=), (@-@), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -697,3 +697,23 @@ spec = do
             /\ minContent
             /\ minmax maxContent (fr 2.8)
         )
+
+    describe "grid-auto-flow property" do
+
+      "grid-auto-flow:inherit" `isRenderedFrom` (gridAutoFlow := inherit)
+
+      "grid-auto-flow:initial" `isRenderedFrom` (gridAutoFlow := initial)
+
+      "grid-auto-flow:unset" `isRenderedFrom` (gridAutoFlow := unset)
+
+      "grid-auto-flow:row" `isRenderedFrom` (gridAutoFlow := row)
+
+      "grid-auto-flow:column" `isRenderedFrom` (gridAutoFlow := column)
+
+      "grid-auto-flow:dense" `isRenderedFrom` (gridAutoFlow := dense)
+
+      "grid-auto-flow:row dense" `isRenderedFrom` (gridAutoFlow := row ~ dense)
+
+      "grid-auto-flow:column dense"
+        `isRenderedFrom`
+        (gridAutoFlow := column ~ dense)

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -599,101 +599,101 @@ spec = do
             /\ pct 71.6
         )
 
-    "grid-auto-columns:fit-content(375.2px) minmax(auto,217.9em) max-content minmax(84.3%,auto)"
-      `isRenderedFrom`
-      ( gridAutoColumns :=
-          fitContent (px 375.2)
-          /\ minmax auto (em 217.9)
-          /\ maxContent
-          /\ minmax (pct 84.3) auto
-      )
+      "grid-auto-columns:fit-content(375.2px) minmax(auto,217.9em) max-content minmax(84.3%,auto)"
+        `isRenderedFrom`
+        ( gridAutoColumns :=
+            fitContent (px 375.2)
+            /\ minmax auto (em 217.9)
+            /\ maxContent
+            /\ minmax (pct 84.3) auto
+        )
 
-    "grid-auto-columns:fit-content(177px) minmax(auto,1fr) max-content max-content"
-      `isRenderedFrom`
-      ( gridAutoColumns :=
-          fitContent (px 177)
-          /\ minmax auto (fr 1)
-          /\ maxContent
-          /\ maxContent
-      )
+      "grid-auto-columns:fit-content(177px) minmax(auto,1fr) max-content max-content"
+        `isRenderedFrom`
+        ( gridAutoColumns :=
+            fitContent (px 177)
+            /\ minmax auto (fr 1)
+            /\ maxContent
+            /\ maxContent
+        )
 
-    "grid-auto-columns:minmax(max-content,max-content) fit-content(39.3%) minmax(max-content,80px) minmax(min-content,2fr)"
-      `isRenderedFrom`
-      ( gridAutoColumns :=
-          minmax maxContent maxContent
-          /\ fitContent (pct 39.3)
-          /\ minmax maxContent (px 80)
-          /\ minmax minContent (fr 2)
-      )
+      "grid-auto-columns:minmax(max-content,max-content) fit-content(39.3%) minmax(max-content,80px) minmax(min-content,2fr)"
+        `isRenderedFrom`
+        ( gridAutoColumns :=
+            minmax maxContent maxContent
+            /\ fitContent (pct 39.3)
+            /\ minmax maxContent (px 80)
+            /\ minmax minContent (fr 2)
+        )
 
-    "grid-auto-columns:minmax(83.8%,auto) fit-content(36.1%)"
-      `isRenderedFrom`
-      (gridAutoColumns := minmax (pct 83.8) auto /\ fitContent (pct 36.1))
+      "grid-auto-columns:minmax(83.8%,auto) fit-content(36.1%)"
+        `isRenderedFrom`
+        (gridAutoColumns := minmax (pct 83.8) auto /\ fitContent (pct 36.1))
 
-  describe "grid-auto-rows property" do
+    describe "grid-auto-rows property" do
 
-    "grid-auto-rows:inherit" `isRenderedFrom` (gridAutoRows := inherit)
+      "grid-auto-rows:inherit" `isRenderedFrom` (gridAutoRows := inherit)
 
-    "grid-auto-rows:initial" `isRenderedFrom` (gridAutoRows := initial)
+      "grid-auto-rows:initial" `isRenderedFrom` (gridAutoRows := initial)
 
-    "grid-auto-rows:unset" `isRenderedFrom` (gridAutoRows := unset)
+      "grid-auto-rows:unset" `isRenderedFrom` (gridAutoRows := unset)
 
-    "grid-auto-rows:calc(25% - 4px)"
-      `isRenderedFrom`
-      (gridAutoRows := pct 25 @-@ px 4)
+      "grid-auto-rows:calc(25% - 4px)"
+        `isRenderedFrom`
+        (gridAutoRows := pct 25 @-@ px 4)
 
-    "grid-auto-rows:2.5fr" `isRenderedFrom` (gridAutoRows := fr 2.5)
+      "grid-auto-rows:2.5fr" `isRenderedFrom` (gridAutoRows := fr 2.5)
 
-    "grid-auto-rows:min-content" `isRenderedFrom` (gridAutoRows := minContent)
+      "grid-auto-rows:min-content" `isRenderedFrom` (gridAutoRows := minContent)
 
-    "grid-auto-rows:max-content" `isRenderedFrom` (gridAutoRows := maxContent)
+      "grid-auto-rows:max-content" `isRenderedFrom` (gridAutoRows := maxContent)
 
-    "grid-auto-rows:auto" `isRenderedFrom` (gridAutoRows := auto)
+      "grid-auto-rows:auto" `isRenderedFrom` (gridAutoRows := auto)
 
-    "grid-auto-rows:minmax(100px,2fr)"
-      `isRenderedFrom`
-      (gridAutoRows := minmax (px 100) (fr 2))
+      "grid-auto-rows:minmax(100px,2fr)"
+        `isRenderedFrom`
+        (gridAutoRows := minmax (px 100) (fr 2))
 
-    "grid-auto-rows:fit-content(100px)"
-      `isRenderedFrom`
-      (gridAutoRows := fitContent $ px 100)
+      "grid-auto-rows:fit-content(100px)"
+        `isRenderedFrom`
+        (gridAutoRows := fitContent $ px 100)
 
-    "grid-auto-rows:fit-content(270.3vw) fit-content(87px)"
-      `isRenderedFrom`
-      (gridAutoRows := fitContent (vw 270.3) /\ fitContent (px 87))
+      "grid-auto-rows:fit-content(270.3vw) fit-content(87px)"
+        `isRenderedFrom`
+        (gridAutoRows := fitContent (vw 270.3) /\ fitContent (px 87))
 
-    "grid-auto-rows:fit-content(318.8vw) fit-content(450.7px) fit-content(319.5em) minmax(min-content,max-content)"
-      `isRenderedFrom`
-      ( gridAutoRows :=
-          fitContent (vw 318.8)
-          /\ fitContent (px 450.7)
-          /\ fitContent (em 319.5)
-          /\ minmax minContent maxContent
-      )
+      "grid-auto-rows:fit-content(318.8vw) fit-content(450.7px) fit-content(319.5em) minmax(min-content,max-content)"
+        `isRenderedFrom`
+        ( gridAutoRows :=
+            fitContent (vw 318.8)
+            /\ fitContent (px 450.7)
+            /\ fitContent (em 319.5)
+            /\ minmax minContent maxContent
+        )
 
-    "grid-auto-rows:min-content minmax(max-content,max-content) fit-content(235.8px) fit-content(22.6px)"
-      `isRenderedFrom`
-      ( gridAutoRows :=
-          minContent
-          /\ minmax maxContent maxContent
-          /\ fitContent (px 235.8)
-          /\ fitContent (px 22.6)
-      )
+      "grid-auto-rows:min-content minmax(max-content,max-content) fit-content(235.8px) fit-content(22.6px)"
+        `isRenderedFrom`
+        ( gridAutoRows :=
+            minContent
+            /\ minmax maxContent maxContent
+            /\ fitContent (px 235.8)
+            /\ fitContent (px 22.6)
+        )
 
-    "grid-auto-rows:minmax(auto,2.6fr) minmax(max-content,min-content) fit-content(389.9em) minmax(max-content,1.5fr)"
-      `isRenderedFrom`
-      ( gridAutoRows :=
-          minmax auto (fr 2.6)
-          /\ minmax maxContent minContent
-          /\ fitContent (em 389.9)
-          /\ minmax maxContent (fr 1.5)
-      )
+      "grid-auto-rows:minmax(auto,2.6fr) minmax(max-content,min-content) fit-content(389.9em) minmax(max-content,1.5fr)"
+        `isRenderedFrom`
+        ( gridAutoRows :=
+            minmax auto (fr 2.6)
+            /\ minmax maxContent minContent
+            /\ fitContent (em 389.9)
+            /\ minmax maxContent (fr 1.5)
+        )
 
-    "grid-auto-rows:minmax(88.1%,min-content) auto min-content minmax(max-content,2.8fr)"
-      `isRenderedFrom`
-      ( gridAutoRows :=
-          minmax (pct 88.1) minContent
-          /\ auto
-          /\ minContent
-          /\ minmax maxContent (fr 2.8)
-      )
+      "grid-auto-rows:minmax(88.1%,min-content) auto min-content minmax(max-content,2.8fr)"
+        `isRenderedFrom`
+        ( gridAutoRows :=
+            minmax (pct 88.1) minContent
+            /\ auto
+            /\ minContent
+            /\ minmax maxContent (fr 2.8)
+        )

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -5,7 +5,7 @@ module Test.GridSpec where
 import Prelude
 
 import Data.Tuple.Nested ((/\))
-import Tecton (auto, autoFill, autoFit, column, dense, em, fitContent, fr, gridAutoColumns, gridAutoFlow, gridAutoRows, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, row, unset, vw, (:=), (@-@), (~))
+import Tecton (auto, autoFill, autoFit, column, dense, em, fitContent, fr, gridAutoColumns, gridAutoFlow, gridAutoRows, gridRowStart, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, row, span, unset, vw, (:=), (@-@), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -717,3 +717,35 @@ spec = do
       "grid-auto-flow:column dense"
         `isRenderedFrom`
         (gridAutoFlow := column ~ dense)
+
+    describe "grid-row-start property" do
+
+      "grid-row-start:inherit" `isRenderedFrom` (gridRowStart := inherit)
+
+      "grid-row-start:initial" `isRenderedFrom` (gridRowStart := initial)
+
+      "grid-row-start:unset" `isRenderedFrom` (gridRowStart := unset)
+
+      "grid-row-start:auto" `isRenderedFrom` (gridRowStart := auto)
+
+      "grid-row-start:sugar" `isRenderedFrom` (gridRowStart := lineName "sugar")
+
+      "grid-row-start:1" `isRenderedFrom` (gridRowStart := 1)
+
+      "grid-row-start:3 mutual"
+        `isRenderedFrom`
+        (gridRowStart := 3 ~ lineName "mutual")
+
+      "grid-row-start:-1 design"
+        `isRenderedFrom`
+        (gridRowStart := (-1) ~ lineName "design")
+
+      "grid-row-start:span 5" `isRenderedFrom` (gridRowStart := span ~ 5)
+
+      "grid-row-start:span robot"
+        `isRenderedFrom`
+        (gridRowStart := span ~ lineName "robot")
+
+      "grid-row-start:span 3 apple"
+        `isRenderedFrom`
+        (gridRowStart := span ~ 3 ~ lineName "apple")

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -5,7 +5,7 @@ module Test.GridSpec where
 import Prelude
 
 import Data.Tuple.Nested ((/\))
-import Tecton (auto, autoFill, autoFit, em, fitContent, fr, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, unset, vw, (:=))
+import Tecton (auto, autoFill, autoFit, em, fitContent, fr, gridAutoColumns, gridAutoRows, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, unset, vw, (:=), (@-@))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -539,3 +539,131 @@ spec = do
                  )
               /\ repeat 2 (minmax (pct 89.6) (vw 65))
           )
+
+    describe "grid-auto-columns" do
+
+      "grid-auto-columns:100px" `isRenderedFrom` (gridAutoColumns := px 100)
+
+      "grid-auto-columns:10%" `isRenderedFrom` (gridAutoColumns := pct 10)
+
+      "grid-auto-columns:1fr" `isRenderedFrom` (gridAutoColumns := fr 1)
+
+      "grid-auto-columns:min-content"
+        `isRenderedFrom`
+        (gridAutoColumns := minContent)
+
+      "grid-auto-columns:max-content"
+        `isRenderedFrom`
+        (gridAutoColumns := maxContent)
+
+      "grid-auto-columns:auto" `isRenderedFrom` (gridAutoColumns := auto)
+
+      "grid-auto-columns:minmax(min-content,auto)"
+        `isRenderedFrom`
+        (gridAutoColumns := minmax minContent auto)
+
+      "grid-auto-columns:fit-content(75%)"
+        `isRenderedFrom`
+        (gridAutoColumns := fitContent $ pct 75)
+
+      "grid-auto-columns:fit-content(379.3vw) minmax(464.4em,227vw) fit-content(18.3%) 71.6%"
+        `isRenderedFrom`
+        ( gridAutoColumns :=
+            fitContent (vw 379.3)
+            /\ minmax (em 464.4) (vw 227)
+            /\ fitContent (pct 18.3)
+            /\ pct 71.6
+        )
+
+    "grid-auto-columns:fit-content(375.2px) minmax(auto,217.9em) max-content minmax(84.3%,auto)"
+      `isRenderedFrom`
+      ( gridAutoColumns :=
+          fitContent (px 375.2)
+          /\ minmax auto (em 217.9)
+          /\ maxContent
+          /\ minmax (pct 84.3) auto
+      )
+
+    "grid-auto-columns:fit-content(177px) minmax(auto,1fr) max-content max-content"
+      `isRenderedFrom`
+      ( gridAutoColumns :=
+          fitContent (px 177)
+          /\ minmax auto (fr 1)
+          /\ maxContent
+          /\ maxContent
+      )
+
+    "grid-auto-columns:minmax(max-content,max-content) fit-content(39.3%) minmax(max-content,80px) minmax(min-content,2fr)"
+      `isRenderedFrom`
+      ( gridAutoColumns :=
+          minmax maxContent maxContent
+          /\ fitContent (pct 39.3)
+          /\ minmax maxContent (px 80)
+          /\ minmax minContent (fr 2)
+      )
+
+    "grid-auto-columns:minmax(83.8%,auto) fit-content(36.1%)"
+      `isRenderedFrom`
+      (gridAutoColumns := minmax (pct 83.8) auto /\ fitContent (pct 36.1))
+
+  describe "grid-auto-rows property" do
+
+    "grid-auto-rows:calc(25% - 4px)"
+      `isRenderedFrom`
+      (gridAutoRows := pct 25 @-@ px 4)
+
+    "grid-auto-rows:2.5fr" `isRenderedFrom` (gridAutoRows := fr 2.5)
+
+    "grid-auto-rows:min-content" `isRenderedFrom` (gridAutoRows := minContent)
+
+    "grid-auto-rows:max-content" `isRenderedFrom` (gridAutoRows := maxContent)
+
+    "grid-auto-rows:auto" `isRenderedFrom` (gridAutoRows := auto)
+
+    "grid-auto-rows:minmax(100px,2fr)"
+      `isRenderedFrom`
+      (gridAutoRows := minmax (px 100) (fr 2))
+
+    "grid-auto-rows:fit-content(100px)"
+      `isRenderedFrom`
+      (gridAutoRows := fitContent $ px 100)
+
+    "grid-auto-rows:fit-content(270.3vw) fit-content(87px)"
+      `isRenderedFrom`
+      (gridAutoRows := fitContent (vw 270.3) /\ fitContent (px 87))
+
+    "grid-auto-rows:fit-content(318.8vw) fit-content(450.7px) fit-content(319.5em) minmax(min-content,max-content)"
+      `isRenderedFrom`
+      ( gridAutoRows :=
+          fitContent (vw 318.8)
+          /\ fitContent (px 450.7)
+          /\ fitContent (em 319.5)
+          /\ minmax minContent maxContent
+      )
+
+    "grid-auto-rows:min-content minmax(max-content,max-content) fit-content(235.8px) fit-content(22.6px)"
+      `isRenderedFrom`
+      ( gridAutoRows :=
+          minContent
+          /\ minmax maxContent maxContent
+          /\ fitContent (px 235.8)
+          /\ fitContent (px 22.6)
+      )
+
+    "grid-auto-rows:minmax(auto,2.6fr) minmax(max-content,min-content) fit-content(389.9em) minmax(max-content,1.5fr)"
+      `isRenderedFrom`
+      ( gridAutoRows :=
+          minmax auto (fr 2.6)
+          /\ minmax maxContent minContent
+          /\ fitContent (em 389.9)
+          /\ minmax maxContent (fr 1.5)
+      )
+
+    "grid-auto-rows:minmax(88.1%,min-content) auto min-content minmax(max-content,2.8fr)"
+      `isRenderedFrom`
+      ( gridAutoRows :=
+          minmax (pct 88.1) minContent
+          /\ auto
+          /\ minContent
+          /\ minmax maxContent (fr 2.8)
+      )

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -16,7 +16,7 @@ spec = do
 
   describe "Grid Layout" do
 
-    describe "gridTemplateColumns property" do
+    describe "grid-template-columns property" do
 
       "grid-template-columns:inherit"
         `isRenderedFrom`
@@ -258,6 +258,24 @@ spec = do
             /\ lineName "parent"
             /\ repeat autoFill (px 446.1 /\ px 310.9)
         )
+
+    describe "grid-template-rows property" do
+
+      "grid-template-rows:inherit"
+        `isRenderedFrom`
+        (gridTemplateRows := inherit)
+
+      "grid-template-rows:initial"
+        `isRenderedFrom`
+        (gridTemplateRows := initial)
+
+      "grid-template-rows:unset"
+        `isRenderedFrom`
+        (gridTemplateRows := unset)
+
+      "grid-template-rows:none"
+        `isRenderedFrom`
+        (gridTemplateRows := none)
 
       "grid-template-rows:[only helmet-exchange] 80.1% repeat(2,[online] minmax(24.6vw,358.9vw) minmax(55%,auto) minmax(92.3%,auto)) repeat(auto-fill,96.2% 20.7% [history]) repeat(2,minmax(75%,auto) [sock-dutch]) repeat(2,259em 11.9%)"
           `isRenderedFrom`
@@ -540,7 +558,13 @@ spec = do
               /\ repeat 2 (minmax (pct 89.6) (vw 65))
           )
 
-    describe "grid-auto-columns" do
+    describe "grid-auto-columns property" do
+
+      "grid-auto-columns:inherit" `isRenderedFrom` (gridAutoColumns := inherit)
+
+      "grid-auto-columns:initial" `isRenderedFrom` (gridAutoColumns := initial)
+
+      "grid-auto-columns:unset" `isRenderedFrom` (gridAutoColumns := unset)
 
       "grid-auto-columns:100px" `isRenderedFrom` (gridAutoColumns := px 100)
 
@@ -607,6 +631,12 @@ spec = do
       (gridAutoColumns := minmax (pct 83.8) auto /\ fitContent (pct 36.1))
 
   describe "grid-auto-rows property" do
+
+    "grid-auto-rows:inherit" `isRenderedFrom` (gridAutoRows := inherit)
+
+    "grid-auto-rows:initial" `isRenderedFrom` (gridAutoRows := initial)
+
+    "grid-auto-rows:unset" `isRenderedFrom` (gridAutoRows := unset)
 
     "grid-auto-rows:calc(25% - 4px)"
       `isRenderedFrom`

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -5,7 +5,7 @@ module Test.GridSpec where
 import Prelude
 
 import Data.Tuple.Nested ((/\))
-import Tecton (auto, autoFill, autoFit, column, dense, em, fitContent, fr, gridAutoColumns, gridAutoFlow, gridAutoRows, gridRowStart, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, row, span, unset, vw, (:=), (@-@), (~))
+import Tecton (auto, autoFill, autoFit, column, dense, em, fitContent, fr, gridAutoColumns, gridAutoFlow, gridAutoRows, gridColumnEnd, gridColumnStart, gridRowEnd, gridRowStart, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, row, span, unset, vw, (:=), (@-@), (~))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
 
@@ -732,10 +732,6 @@ spec = do
 
       "grid-row-start:1" `isRenderedFrom` (gridRowStart := 1)
 
-      "grid-row-start:3 mutual"
-        `isRenderedFrom`
-        (gridRowStart := 3 ~ lineName "mutual")
-
       "grid-row-start:-1 design"
         `isRenderedFrom`
         (gridRowStart := (-1) ~ lineName "design")
@@ -749,3 +745,87 @@ spec = do
       "grid-row-start:span 3 apple"
         `isRenderedFrom`
         (gridRowStart := span ~ 3 ~ lineName "apple")
+
+    describe "grid-column-start property" do
+
+      "grid-column-start:inherit" `isRenderedFrom` (gridColumnStart := inherit)
+
+      "grid-column-start:initial" `isRenderedFrom` (gridColumnStart := initial)
+
+      "grid-column-start:unset" `isRenderedFrom` (gridColumnStart := unset)
+
+      "grid-column-start:auto" `isRenderedFrom` (gridColumnStart := auto)
+
+      "grid-column-start:pilot"
+        `isRenderedFrom`
+        (gridColumnStart := lineName "pilot")
+
+      "grid-column-start:6" `isRenderedFrom` (gridColumnStart := 6)
+
+      "grid-column-start:5 pattern"
+        `isRenderedFrom`
+        (gridColumnStart := 5 ~ lineName "pattern")
+
+      "grid-column-start:span 8" `isRenderedFrom` (gridColumnStart := span ~ 8)
+
+      "grid-column-start:span confident"
+        `isRenderedFrom`
+        (gridColumnStart := span ~ lineName "confident")
+
+      "grid-column-start:span 2 around-noise"
+        `isRenderedFrom`
+        (gridColumnStart := span ~ 2 ~ lineName "around-noise")
+
+    describe "grid-row-end property" do
+
+      "grid-row-end:inherit" `isRenderedFrom` (gridRowEnd := inherit)
+
+      "grid-row-end:initial" `isRenderedFrom` (gridRowEnd := initial)
+
+      "grid-row-end:unset" `isRenderedFrom` (gridRowEnd := unset)
+
+      "grid-row-end:auto" `isRenderedFrom` (gridRowEnd := auto)
+
+      "grid-row-end:minute" `isRenderedFrom` (gridRowEnd := lineName "minute")
+
+      "grid-row-end:-5" `isRenderedFrom` (gridRowEnd := (-5))
+
+      "grid-row-end:8 this" `isRenderedFrom` (gridRowEnd := 8 ~ lineName "this")
+
+      "grid-row-end:span down"
+        `isRenderedFrom`
+        (gridRowEnd := span ~ lineName "down")
+
+      "grid-row-end:span 4" `isRenderedFrom` (gridRowEnd := span ~ 4)
+
+      "grid-row-end:span 4 plate"
+        `isRenderedFrom`
+        (gridRowEnd := span ~ 4 ~ lineName "plate")
+
+    describe "grid-column-end property" do
+
+      "grid-column-end:inherit" `isRenderedFrom` (gridColumnEnd := inherit)
+
+      "grid-column-end:initial" `isRenderedFrom` (gridColumnEnd := initial)
+
+      "grid-column-end:unset" `isRenderedFrom` (gridColumnEnd := unset)
+
+      "grid-column-end:auto" `isRenderedFrom` (gridColumnEnd := auto)
+
+      "grid-column-end:book" `isRenderedFrom` (gridColumnEnd := lineName "book")
+
+      "grid-column-end:25" `isRenderedFrom` (gridColumnEnd := 25)
+
+      "grid-column-end:4 school"
+        `isRenderedFrom`
+        (gridColumnEnd := 4 ~ lineName "school")
+
+      "grid-column-end:span waterfall"
+        `isRenderedFrom`
+        (gridColumnEnd := span ~ lineName "waterfall")
+
+      "grid-column-end:span 9" `isRenderedFrom` (gridColumnEnd := span ~ 9)
+
+      "grid-column-end:span 2 paddle"
+        `isRenderedFrom`
+        (gridColumnEnd := span ~ 2 ~ lineName "paddle")

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -1,0 +1,541 @@
+-- https://www.w3.org/TR/css-grid-2/
+
+module Test.GridSpec where
+
+import Prelude
+
+import Data.Tuple.Nested ((/\))
+import Tecton (auto, autoFill, autoFit, em, fitContent, fr, gridTemplateColumns, gridTemplateRows, inherit, initial, lineName, maxContent, minContent, minmax, none, pct, px, repeat, unset, vw, (:=))
+import Test.Spec (Spec, describe)
+import Test.Util (isRenderedFromInline)
+
+spec :: Spec Unit
+spec = do
+
+  let isRenderedFrom = isRenderedFromInline
+
+  describe "Grid Layout" do
+
+    describe "gridTemplateColumns property" do
+
+      "grid-template-columns:inherit"
+        `isRenderedFrom`
+        (gridTemplateColumns := inherit)
+
+      "grid-template-columns:initial"
+        `isRenderedFrom`
+        (gridTemplateColumns := initial)
+
+      "grid-template-columns:unset"
+        `isRenderedFrom`
+        (gridTemplateColumns := unset)
+
+      "grid-template-columns:none"
+        `isRenderedFrom`
+        (gridTemplateColumns := none)
+      
+      "grid-template-columns:[attend settle] repeat(3,[document-festival] fit-content(421.3px) auto fit-content(399.6px))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "attend"
+            /\ lineName "settle"
+            /\ repeat 3
+               ( lineName "document-festival"
+                 /\ fitContent (px 421.3)
+                 /\ auto
+                 /\ fitContent (px 399.6)
+               )
+        )
+
+      "grid-template-columns:repeat(auto-fit,53.1% minmax(138.5px,auto) [resist]) minmax(6.1%,max-content)"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat autoFit
+            ( pct 53.1
+              /\ minmax (px 138.5) auto
+              /\ lineName "resist"
+            )
+            /\ minmax (pct 6.1) maxContent
+        )
+
+      "grid-template-columns:repeat(auto-fit,21.4px 90.5%) [despair-stage join-burden true-genius]"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat autoFit
+            ( px 21.4
+              /\ pct 90.5
+            )
+            /\ lineName "despair-stage"
+            /\ lineName "join-burden"
+            /\ lineName "true-genius"
+        )
+
+      "grid-template-columns:repeat(3,[leg] minmax(max-content,475px) max-content [mutual])"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat 3
+            ( lineName "leg"
+              /\ minmax maxContent (px 475)
+              /\ maxContent
+              /\ lineName "mutual"
+            )
+        )
+
+      "grid-template-columns:21% [tobacco mandate] repeat(auto-fill,minmax(172.8vw,max-content) 60.7% 384.7vw) [wide]"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            pct 21
+            /\ lineName "tobacco"
+            /\ lineName "mandate"
+            /\ repeat autoFill
+               ( minmax (vw 172.8) maxContent
+                 /\ pct 60.7
+                 /\ vw 384.7
+               )
+            /\ lineName "wide"
+        )
+
+      "grid-template-columns:[also] 27.8% repeat(auto-fill,minmax(29.5%,13.8%) minmax(76.2%,2fr))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "also"
+            /\ pct 27.8
+            /\ repeat autoFill
+               ( minmax (pct 29.5) (pct 13.8)
+                 /\ minmax (pct 76.2) (fr 2)
+               )
+        )
+
+      "grid-template-columns:fit-content(153.5vw)"
+        `isRenderedFrom`
+        (gridTemplateColumns := fitContent (vw 153.5))
+
+      "grid-template-columns:repeat(5,auto minmax(min-content,max-content) [afraid-pony ask-group])"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat 5
+            ( auto
+              /\ minmax minContent maxContent
+              /\ lineName "afraid-pony"
+              /\ lineName "ask-group"
+            )
+        )
+
+      "grid-template-columns:minmax(max-content,1.1fr)"
+        `isRenderedFrom`
+        (gridTemplateColumns := minmax maxContent $ fr 1.1)
+
+      "grid-template-columns:repeat(auto-fill,[family] 453.2vw 76.2%) repeat(1,minmax(121.1px,2fr) 329.5vw 67.2%)"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat autoFill (lineName "family" /\ vw 453.2 /\ pct 76.2)
+            /\ repeat 1 (minmax (px 121.1) (fr 2) /\ vw 329.5 /\ pct 67.2)
+        )
+
+      "grid-template-columns:[arrive] minmax(max-content,1.7fr) [repeat-emerge]"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "arrive"
+            /\ minmax maxContent (fr 1.7)
+            /\ lineName "repeat-emerge"
+        )
+
+      "grid-template-columns:[theme-aim argue-master] repeat(auto-fill,25.2% minmax(11%,1.8fr) [rigid-immense]) [wife ahead option-purpose]"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "theme-aim"
+            /\ lineName "argue-master"
+            /\ repeat autoFill
+               ( pct 25.2
+                 /\ minmax (pct 11) (fr 1.8)
+                 /\ lineName "rigid-immense"
+               )
+            /\ lineName "wife"
+            /\ lineName "ahead"
+            /\ lineName "option-purpose"
+        )
+
+      "grid-template-columns:repeat(auto-fill,minmax(38%,min-content) 467vw)"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat autoFill (minmax (pct 38) minContent /\ vw 467)
+        )
+
+      "grid-template-columns:minmax(auto,385vw)"
+        `isRenderedFrom`
+        (gridTemplateColumns := minmax auto $ vw 385)
+
+      "grid-template-columns:440.2px repeat(auto-fill,minmax(475.2vw,auto) minmax(7.9%,71.3%) minmax(271.8em,max-content))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            px 440.2
+            /\ repeat autoFill
+               ( minmax (vw 475.2) auto
+                 /\ minmax (pct 7.9) (pct 71.3)
+                 /\ minmax (em 271.8) maxContent
+               )
+        )
+
+      "grid-template-columns:repeat(2,minmax(min-content,57.4%) fit-content(71%))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat 2 $ minmax minContent (pct 57.4) /\ fitContent (pct 71)
+        )
+
+      "grid-template-columns:[pass] repeat(1,[foot-battle brother trick-category] fit-content(21.5em) minmax(min-content,min-content) [salad])"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "pass"
+            /\ repeat 1
+               ( lineName "foot-battle"
+                 /\ lineName "brother"
+                 /\ lineName "trick-category"
+                 /\ fitContent (em 21.5)
+                 /\ minmax minContent minContent
+                 /\ lineName "salad"
+               )
+        )
+
+      "grid-template-columns:[replace-another] repeat(4,[inmate valley believe] minmax(auto,2.5fr) fit-content(26%) [find])"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "replace-another"
+            /\ repeat 4
+               ( lineName "inmate"
+                 /\ lineName "valley"
+                 /\ lineName "believe"
+                 /\ minmax auto (fr 2.5)
+                 /\ fitContent (pct 26)
+                 /\ lineName "find"
+               )
+        )
+
+      "grid-template-columns:repeat(auto-fill,[mask] 76.5% 191vw 17em)"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat autoFill $ lineName "mask" /\ pct 76.5 /\ vw 191 /\ em 17
+        )
+
+      "grid-template-columns:[shoulder-flavor] repeat(2,1.2fr fit-content(187.1em))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "shoulder-flavor"
+            /\ repeat 2 (fr 1.2 /\ fitContent (em 187.1))
+        )
+
+      "grid-template-columns:repeat(auto-fill,minmax(404.2px,min-content) 91.6%)"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat autoFill $ minmax (px 404.2) minContent /\ pct 91.6
+        )
+
+      "grid-template-columns:repeat(2,[fetch-silent] minmax(24.2%,28%) minmax(auto,min-content))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            repeat 2
+            ( lineName "fetch-silent"
+              /\ minmax (pct 24.2) (pct 28)
+              /\ minmax auto minContent
+            )
+        )
+
+      "grid-template-columns:minmax(14.2%,max-content)"
+        `isRenderedFrom`
+        (gridTemplateColumns := minmax (pct 14.2) maxContent)
+
+      "grid-template-columns:[spot] repeat(4,[idea-forum] 80% fit-content(55vw))"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "spot"
+            /\ repeat 4 (lineName "idea-forum" /\ pct 80 /\ fitContent (vw 55))
+        )
+
+      "grid-template-columns:[salmon-crop among parent] repeat(auto-fill,446.1px 310.9px)"
+        `isRenderedFrom`
+        ( gridTemplateColumns :=
+            lineName "salmon-crop"
+            /\ lineName "among"
+            /\ lineName "parent"
+            /\ repeat autoFill (px 446.1 /\ px 310.9)
+        )
+
+      "grid-template-rows:[only helmet-exchange] 80.1% repeat(2,[online] minmax(24.6vw,358.9vw) minmax(55%,auto) minmax(92.3%,auto)) repeat(auto-fill,96.2% 20.7% [history]) repeat(2,minmax(75%,auto) [sock-dutch]) repeat(2,259em 11.9%)"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              lineName "only"
+              /\ lineName "helmet-exchange"
+              /\ pct 80.1
+              /\ repeat 2
+                 ( lineName "online"
+                   /\ minmax (vw 24.6) (vw 358.9)
+                   /\ minmax (pct 55) auto
+                   /\ minmax (pct 92.3) auto
+                 )
+              /\ repeat autoFill (pct 96.2 /\ pct 20.7 /\ lineName "history")
+              /\ repeat 2 (minmax (pct 75) auto /\ lineName "sock-dutch") 
+              /\ repeat 2 (em 259 /\ pct 11.9)
+          )
+
+      "grid-template-rows:minmax(396em,max-content) repeat(auto-fill,354.8em [crash]) [melt chief]"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              minmax (em 396) maxContent
+              /\ repeat autoFill (em 354.8 /\ lineName "crash")
+              /\ lineName "melt"
+              /\ lineName "chief"
+          )
+
+      "grid-template-rows:repeat(2,minmax(69.7%,auto) minmax(169.6px,2fr)) [square copper-venture] repeat(auto-fill,[device-banana] 15% minmax(57%,auto) [tiger-desk legal-sign stereo-rocket]) [giant-kid]"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 2 (minmax (pct 69.7) auto /\ minmax (px 169.6) (fr 2))
+              /\ lineName "square"
+              /\ lineName "copper-venture"
+              /\ repeat autoFill 
+                 ( lineName "device-banana"
+                   /\ pct 15
+                   /\ minmax (pct 57) auto
+                   /\ lineName "tiger-desk"
+                   /\ lineName "legal-sign"
+                   /\ lineName "stereo-rocket"
+                 )
+              /\ lineName "giant-kid"
+          )
+
+      "grid-template-rows:minmax(max-content,2fr)"
+          `isRenderedFrom`
+          (gridTemplateRows := minmax maxContent $ fr 2)
+
+      "grid-template-rows:repeat(1,477vw 7.2% [dumb-anger]) repeat(auto-fit,297.5px minmax(43.3%,auto))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 1 (vw 477 /\ pct 7.2 /\ lineName "dumb-anger")
+              /\ repeat autoFit (px 297.5 /\ minmax (pct 43.3) auto)
+          )
+
+      "grid-template-rows:min-content"
+          `isRenderedFrom`
+          (gridTemplateRows := minContent)
+
+      "grid-template-rows:repeat(3,minmax(31.4%,auto) [stable-small]) repeat(auto-fit,minmax(40.8%,max-content) minmax(129.6vw,154px) [noble]) minmax(447.9px,min-content)"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 3 (minmax (pct 31.4) auto /\ lineName "stable-small")
+              /\ repeat autoFit
+                 ( minmax (pct 40.8) maxContent
+                   /\ minmax (vw 129.6) (px 154)
+                   /\ lineName "noble"
+                 )
+              /\ minmax (px 447.9) minContent
+          )
+
+      "grid-template-rows:fit-content(491em)"
+          `isRenderedFrom`
+          (gridTemplateRows := fitContent $ em 491)
+
+      "grid-template-rows:minmax(54%,40.4%) repeat(1,378.4em minmax(40.9%,max-content)) repeat(auto-fill,[inner-uphold] minmax(450.8px,auto) minmax(96.1em,1.9fr)) [usual-brave] repeat(2,minmax(456.8em,max-content) 127.6px) repeat(1,184vw 11.9%)"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              minmax (pct 54) (pct 40.4)
+              /\ repeat 1 (em 378.4 /\ minmax (pct 40.9) maxContent)
+              /\ repeat autoFill
+                 ( lineName "inner-uphold"
+                   /\ minmax (px 450.8) auto
+                   /\ minmax (em 96.1) (fr 1.9)
+                 )
+              /\ lineName "usual-brave"
+              /\ repeat 2 (minmax (em 456.8) maxContent /\ px 127.6)
+              /\ repeat 1 (vw 184 /\ pct 11.9)
+          )
+
+      "grid-template-rows:[spirit-dawn either deliver] repeat(auto-fill,minmax(38.1%,auto) 434em) repeat(1,minmax(482.1em,24.9%) minmax(90.7%,min-content)) minmax(358.2px,max-content)"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              lineName "spirit-dawn"
+              /\ lineName "either"
+              /\ lineName "deliver"
+              /\ repeat autoFill (minmax (pct 38.1) auto /\ em 434)
+              /\ repeat 1
+                 ( minmax (em 482.1) (pct 24.9)
+                   /\ minmax (pct 90.7) minContent
+                 )
+              /\ minmax (px 358.2) maxContent
+          )
+
+      "grid-template-rows:repeat(4,min-content minmax(max-content,48.4%) fit-content(63.7%))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 4
+              ( minContent
+                /\ minmax maxContent (pct 48.4)
+                /\ fitContent (pct 63.7)
+              )
+          )
+
+      "grid-template-rows:repeat(auto-fill,67.1% 75% minmax(95%,min-content) [unlock-already luggage]) [grocery-father]"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat autoFill
+              ( pct 67.1
+                /\ pct 75
+                /\ minmax (pct 95) minContent
+                /\ lineName "unlock-already"
+                /\ lineName "luggage"
+              )
+              /\ lineName "grocery-father"
+          )
+
+      "grid-template-rows:repeat(5,[toward-crystal] minmax(min-content,94.4%) fit-content(216.5vw) minmax(min-content,30.1%))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 5
+              ( lineName "toward-crystal"
+                /\ minmax minContent (pct 94.4)
+                /\ fitContent (vw 216.5)
+                /\ minmax minContent (pct 30.1)
+              )
+          )
+
+      "grid-template-rows:repeat(4,min-content minmax(max-content,2fr) minmax(min-content,max-content))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 4
+              ( minContent
+                /\ minmax maxContent (fr 2)
+                /\ minmax minContent maxContent
+              )
+          )
+
+      "grid-template-rows:[shove] repeat(1,minmax(max-content,min-content) minmax(auto,336.2vw) [habit-type cool-bronze melody-trip])"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              lineName "shove"
+              /\ repeat 1
+                 ( minmax maxContent minContent
+                   /\ minmax auto (vw 336.2)
+                   /\ lineName "habit-type"
+                   /\ lineName "cool-bronze"
+                   /\ lineName "melody-trip"
+                 )
+          )
+
+      "grid-template-rows:repeat(2,minmax(84.1%,min-content) 36%) repeat(1,24.9%) repeat(auto-fit,minmax(182.7em,min-content) 442.4em [unhappy aunt sunny])"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 2 (minmax (pct 84.1) minContent /\ pct 36)
+              /\ repeat 1 (pct 24.9)
+              /\ repeat autoFit
+                 ( minmax (em 182.7) minContent
+                   /\ em 442.4
+                   /\ lineName "unhappy"
+                   /\ lineName "aunt"
+                   /\ lineName "sunny"
+                 )
+          )
+
+      "grid-template-rows:[wedding-impose gloom] repeat(auto-fill,176.1px 483.8vw minmax(48.5%,auto))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              lineName "wedding-impose"
+              /\ lineName "gloom"
+              /\ repeat autoFill
+                 ( px 176.1
+                   /\ vw 483.8
+                   /\ minmax (pct 48.5) auto
+                 )
+          )
+
+      "grid-template-rows:repeat(auto-fill,33.5vw) [garlic potato drill]"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat autoFill (vw 33.5)
+              /\ lineName "garlic"
+              /\ lineName "potato"
+              /\ lineName "drill"
+          )
+
+      "grid-template-rows:42% 52.3% repeat(auto-fit,52.6% [syrup]) 36.2% minmax(36.6%,auto) [fever]"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              pct 42
+              /\ pct 52.3
+              /\ repeat autoFit (pct 52.6 /\ lineName "syrup")
+              /\ pct 36.2
+              /\ minmax (pct 36.6) auto
+              /\ lineName "fever"
+          )
+
+      "grid-template-rows:max-content"
+          `isRenderedFrom`
+          (gridTemplateRows := maxContent)
+
+      "grid-template-rows:repeat(5,fit-content(92.4%) 55.7% [stomach-myself])"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 5
+              ( fitContent (pct 92.4)
+                /\ pct 55.7
+                /\ lineName "stomach-myself"
+              )
+          )
+
+      "grid-template-rows:[arch-smoke harvest link-common] repeat(2,minmax(max-content,51vw) auto fit-content(70.1%))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              lineName "arch-smoke"
+              /\ lineName "harvest"
+              /\ lineName "link-common"
+              /\ repeat 2
+                 ( minmax maxContent (vw 51)
+                   /\ auto
+                   /\ fitContent (pct 70.1)
+                 )
+          )
+
+      "grid-template-rows:repeat(auto-fill,minmax(89.1%,55.3px)) minmax(86.9%,1.1fr) minmax(224.8px,auto) [dose-spatial]"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat autoFill (minmax (pct 89.1) (px 55.3))
+              /\ minmax (pct 86.9) (fr 1.1)
+              /\ minmax (px 224.8) auto
+              /\ lineName "dose-spatial"
+          )
+
+      "grid-template-rows:repeat(3,[trap] minmax(400.1vw,244.6px) 58em minmax(69.2%,max-content)) repeat(3,419em 47%) repeat(auto-fill,[expose-focus curious-coconut stone-cigar] 54.3% minmax(9.6%,max-content) minmax(69%,119.4vw)) repeat(2,[buyer-stage] minmax(7%,9.6%) 62.8%)"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              repeat 3
+              ( lineName "trap"
+                /\ minmax (vw 400.1) (px 244.6)
+                /\ em 58
+                /\ minmax (pct 69.2) maxContent
+              )
+              /\ repeat 3 (em 419 /\ pct 47)
+              /\ repeat autoFill
+                 ( lineName "expose-focus"
+                   /\ lineName "curious-coconut"
+                   /\ lineName "stone-cigar"
+                   /\ pct 54.3
+                   /\ minmax (pct 9.6) maxContent
+                   /\ minmax (pct 69) (vw 119.4)
+                  )
+               /\ repeat 2
+                  ( lineName "buyer-stage"
+                    /\ minmax (pct 7) (pct 9.6)
+                    /\ pct 62.8
+                  )
+          )
+
+      "grid-template-rows:[lottery omit-hockey] repeat(auto-fill,minmax(15.4%,min-content) minmax(492vw,max-content) 498.6px [taxi]) repeat(2,minmax(89.6%,65vw))"
+          `isRenderedFrom`
+          ( gridTemplateRows :=
+              lineName "lottery"
+              /\ lineName "omit-hockey"
+              /\ repeat autoFill
+                 ( minmax (pct 15.4) minContent
+                   /\ minmax (vw 492) maxContent
+                   /\ px 498.6
+                   /\ lineName "taxi"
+                 )
+              /\ repeat 2 (minmax (pct 89.6) (vw 65))
+          )

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,6 +16,7 @@ import Test.ContentSpec as Content
 import Test.DisplaySpec as Display
 import Test.FlexboxSpec as Flexbox
 import Test.FontsSpec as Fonts
+import Test.GridSpec as Grid
 import Test.ImagesSpec as Images
 import Test.InlineSpec as Inline
 import Test.ListsSpec as Lists
@@ -48,6 +49,7 @@ main =
       Display.spec
       Flexbox.spec
       Fonts.spec
+      Grid.spec
       Images.spec
       Inline.spec
       Lists.spec


### PR DESCRIPTION
### Description

This adds support for most of the CSS Grid specification. It also brings some properties previously implemented per the Flexbox spec into alignment with the Box Alignment spec. (Oddly, these properties are defined in multiple specifications; but their supported values per Box Alignment are supersets of their supported values per Flexbox.)

### Design considerations

* I decided to implement Grid Layout Module Level 1 instead of Level 2. The reasons are twofold:
  * Subgrids, which I understand to be the main feature of the Level 2 spec, [aren't well-supported](https://caniuse.com/?search=subgrid).
  * Subgrids use [`<line-name-list>`s](https://www.w3.org/TR/css-grid-2/#typedef-line-name-list) which don't translate well to our current list syntax. It is unclear how to represent multiple lines with multiple names, e.g. `[alpha beta] [gamma] [delta epsilon zeta]` which we would be inclined to write as `alpha /\ beta /\ gamma /\ delta /\ epsilon /\ zeta`, i.e. no grouping.
* I didn't bother with [`grid-template-areas`](https://www.w3.org/TR/css-grid-1/#propdef-grid-template-areas) because its purpose as I understand is to visualize the structure of the grid, which I'm not sure translates well to this library; and I'm not aware of anything that can't be done with `grid-template-columns`, `grid-auto-rows`, etc.

### Future plans

* Continue thinking about possible subgrid and `grid-template-areas` syntax.
* Monitor browser support for subgrid.

### References

* [CSS Grid Layout Module Level 1](https://www.w3.org/TR/css-grid-1/)
* [CSS Box Alignment Module Level 3](https://www.w3.org/TR/css-align-3/)
* [CSS Grid Layout Module Level 2](https://www.w3.org/TR/css-grid-2/) (not implemented)
* ["subgrid" | Can I use...](https://caniuse.com/?search=subgrid)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
