### PR TITLE
`:focus-within` pseudo-class; resolves #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 Breaking changes:
 
 New features:
+- `:focus-within` pseudo-class
 
 Bugfixes:
 

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -209,6 +209,7 @@ import Tecton.Internal
   , float
   , flowRoot
   , focus
+  , focusWithin
   , fontFace
   , fontFamily
   , fontSize

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -428,6 +428,7 @@ module Tecton.Internal
   , float
   , flowRoot
   , focus
+  , focusWithin
   , foldlMultiVal
   , foldLineNames
   , fontFace
@@ -6187,6 +6188,11 @@ empty = PseudoClass $ val "empty"
 
 not :: forall s. IsSelectorList s => MultiVal s => s -> PseudoClass
 not s = PseudoClass $ fn "not" s
+
+-- https://www.w3.org/TR/selectors-4/#focus-within-pseudo
+
+focusWithin :: PseudoClass
+focusWithin = PseudoClass $ val "focus-within"
 
 -- https://www.w3.org/TR/selectors-3/#sel-first-line
 

--- a/test/SelectorsSpec.purs
+++ b/test/SelectorsSpec.purs
@@ -7,7 +7,7 @@ module Test.SelectorsSpec where
 import Prelude hiding (not)
 
 import Data.Tuple.Nested ((/\))
-import Tecton (a, active, after, att, before, checked, disabled, empty, enabled, even, firstChild, firstLetter, firstLine, firstOfType, focus, hover, href, hreflang, indeterminate, lang, lastChild, lastOfType, link, nil, not, nth, nthChild, nthLastChild, nthOfType, odd, onlyChild, onlyOfType, placeholder, root, selection, span, target, title, universal, visited, width, ($=), (&#), (&.), (&:), (&@), (*=), (?), (@=), (^=), (|*), (|+), (|=), (|>), (|~), (~=), (:=))
+import Tecton (a, active, after, att, before, checked, disabled, empty, enabled, even, firstChild, firstLetter, firstLine, firstOfType, focus, focusWithin, hover, href, hreflang, indeterminate, lang, lastChild, lastOfType, link, nil, not, nth, nthChild, nthLastChild, nthOfType, odd, onlyChild, onlyOfType, placeholder, root, selection, span, target, title, universal, visited, width, ($=), (&#), (&.), (&:), (&@), (*=), (?), (@=), (^=), (|*), (|+), (|=), (|>), (|~), (~=), (:=))
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromSheet)
 
@@ -188,6 +188,10 @@ spec = do
       "*:not(*,*){width:0}"
         `isRenderedFrom` do
         universal &: not (universal /\ universal) ? width := nil
+
+      "*:focus-within{width:0}"
+        `isRenderedFrom` do
+        universal &: focusWithin ? width := nil
 
     describe "Pseudo-elements" do
 


### PR DESCRIPTION
### Description

As mentioned in #15, this adds support for the `:focus-within` pseudo-class.

### Design considerations

Not much to say here: I just followed the existing patterns used for other pseudo-classes.

### Future plans

N/A

### References

* [Selectors Level 4: The `:focus-within` pseudo-class](http://w3.org/TR/selectors-4/#the-focus-within-pseudo)
* Related issue #15

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
