### PR TITLE
Docs: Fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Package set](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nsaunders/purescript-tecton/master/meta/registry-status.json)](https://github.com/purescript/registry)
 [![Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/nsaunders/purescript-tecton/master/meta/test-count.json)](./test)
 
-Tecton is a domain-specific language for authoring CSS, embedded in PureScript. The unique capabilities of PureScript allow Tecton's strongly-typed interface to guard against a wide range of [errors](examples/TypeSafety.purs) while offering a developer experience comparable to that of authoring CSS directly.
+Tecton is a domain-specific language for authoring CSS, embedded in PureScript. The unique capabilities of PureScript allow Tecton's strongly-typed interface to guard against a wide range of [errors](examples/type-errors) while offering a developer experience comparable to that of authoring CSS directly.
 
 ## Quick example
 


### PR DESCRIPTION
Small fix of a dead link. The new path is a guess, though.