### PR TITLE
Adds `word-break` property. Resolves #14.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
 
 New features:
 - `box-sizing` property nsaunders/purescript-tecton#31
+- `word-break` property nsaunders/purescript-tecton#32
 
 Bugfixes:
 

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -93,7 +93,9 @@ import Tecton.Internal
   , bottom
   , boxShadow
   , boxSizing
+  , breakAll
   , breakSpaces
+  , breakWord
   , button
   , cambodian
   , canvas
@@ -302,6 +304,7 @@ import Tecton.Internal
   , kannada
   , katakana
   , katakanaIroha
+  , keepAll
   , keyframes
   , keyframesName
   , khmer
@@ -697,6 +700,7 @@ import Tecton.Internal
   , width
   , woff
   , woff2
+  , wordBreak
   , wordSpacing
   , wrap
   , wrapReverse

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -173,6 +173,8 @@ module Tecton.Internal
   , bottom
   , boxShadow
   , boxSizing
+  , breakAll
+  , breakWord
   , breakSpaces
   , button
   , byAtt
@@ -348,6 +350,7 @@ module Tecton.Internal
   , class VisibilityKeyword
   , class WhiteSpaceKeyword
   , class WidthKeyword
+  , class WordBreakKeyword
   , class'
   , clear
   , clip
@@ -549,6 +552,7 @@ module Tecton.Internal
   , kannada
   , katakana
   , katakanaIroha
+  , keepAll
   , keyframes
   , keyframesName
   , khmer
@@ -955,6 +959,7 @@ module Tecton.Internal
   , width
   , woff
   , woff2
+  , wordBreak
   , wordSpacing
   , wrap
   , wrapReverse
@@ -6444,6 +6449,32 @@ instance declarationWhiteSpace ::
   , ToVal (Proxy s)
   ) =>
   Declaration "white-space" (Proxy s) where
+  pval = const val
+
+-- https://www.w3.org/TR/css-text-3/#propdef-word-break
+
+wordBreak = Proxy :: Proxy "word-break"
+
+instance Property "word-break"
+
+keepAll = Proxy :: Proxy "keep-all"
+
+breakAll = Proxy :: Proxy "break-all"
+
+breakWord = Proxy :: Proxy "break-word"
+
+class WordBreakKeyword (s :: Symbol)
+
+instance WordBreakKeyword "normal"
+instance WordBreakKeyword "keep-all"
+instance WordBreakKeyword "break-all"
+instance WordBreakKeyword "break-word"
+
+instance declarationWordBreak ::
+  ( WordBreakKeyword s
+  , ToVal (Proxy s)
+  ) =>
+  Declaration "word-break" (Proxy s) where
   pval = const val
 
 -- https://www.w3.org/TR/css-text-3/#propdef-text-align

--- a/test/TextSpec.purs
+++ b/test/TextSpec.purs
@@ -5,7 +5,9 @@ module Test.TextSpec where
 import Prelude
 
 import Tecton
-  ( breakSpaces
+  ( breakAll
+  , breakSpaces
+  , breakWord
   , capitalize
   , center
   , em
@@ -16,6 +18,7 @@ import Tecton
   , initial
   , justify
   , justifyAll
+  , keepAll
   , left
   , letterSpacing
   , lowercase
@@ -36,6 +39,7 @@ import Tecton
   , unset
   , uppercase
   , whiteSpace
+  , wordBreak
   , wordSpacing
   , (:=)
   , (~)
@@ -161,3 +165,19 @@ spec = do
       "text-indent:10px" `isRenderedFrom` (textIndent := px 10)
 
       "text-indent:2.5%" `isRenderedFrom` (textIndent := pct 2.5)
+
+    describe "word-break property" do
+
+      "word-break:inherit" `isRenderedFrom` (wordBreak := inherit)
+
+      "word-break:initial" `isRenderedFrom` (wordBreak := initial)
+
+      "word-break:unset" `isRenderedFrom` (wordBreak := unset)
+
+      "word-break:normal" `isRenderedFrom` (wordBreak := normal)
+
+      "word-break:keep-all" `isRenderedFrom` (wordBreak := keepAll)
+
+      "word-break:break-all" `isRenderedFrom` (wordBreak := breakAll)
+
+      "word-break:break-word" `isRenderedFrom` (wordBreak := breakWord)


### PR DESCRIPTION
### Description

This change adds support for the `word-break` property to the library.

### Design considerations

N/A

### Future plans

N/A

### References

* [CSS Text Module Level 3: The 'word-break' property (W3C)](https://www.w3.org/TR/css-text-3/#propdef-word-break)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
