### PR TITLE
Drop keyframesName function, exposing KeyframesName constructor instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 
 Breaking changes:
 - _For pseudo-elements only_, the `&:` operator has bee replaced by `&::`. Pseudo-classes continue to work with the `&:` operator. (nsaunders/purescript-tecton#33)
+- The `keyframesName` function has been dropped. Just use the `KeyframesName` constructor instead. (nsaunders/purescript-tecton#34)
 
 For example:
 

--- a/examples/ZenGarments.purs
+++ b/examples/ZenGarments.purs
@@ -7,7 +7,8 @@ import Data.Tuple.Nested ((/\))
 import Effect (Effect)
 import Effect.Console (log)
 import Tecton
-  ( a
+  ( KeyframesName(..)
+  , a
   , abbr
   , absolute
   , acronym
@@ -77,7 +78,6 @@ import Tecton
   , input
   , italic
   , keyframes
-  , keyframesName
   , label
   , left
   , letterSpacing
@@ -892,7 +892,7 @@ main = log $ renderSheet pretty do
 
   -- Animations
 
-  let fadey = keyframesName "FADEY"
+  let fadey = KeyframesName "FADEY"
 
   keyframes fadey ? do
     pct 0 ? Rule.do

--- a/examples/type-errors/KeyframesNonAnimatableProperty.purs
+++ b/examples/type-errors/KeyframesNonAnimatableProperty.purs
@@ -13,12 +13,21 @@ module TypeError.KeyframesNonAnimatableProperty where
 
 import Prelude
 
-import Tecton (CSS, content, keyframes, keyframesName, nil, pct, (:=), (?))
+import Tecton
+  ( CSS
+  , KeyframesName(..)
+  , content
+  , keyframes
+  , nil
+  , pct
+  , (:=)
+  , (?)
+  )
 import Tecton.Rule as Rule
 
 css :: CSS
 css = do
-  keyframes (keyframesName "foo") ? do
+  keyframes (KeyframesName "foo") ? do
     pct 0 ? Rule.do
       content := ""
     pct 100 ? Rule.do

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -4,7 +4,7 @@ import Tecton.Internal
   ( CSS
   , CustomAttribute
   , Declarations
-  , KeyframesName
+  , KeyframesName(..)
   , a
   , abbr
   , absolute
@@ -306,7 +306,6 @@ import Tecton.Internal
   , katakanaIroha
   , keepAll
   , keyframes
-  , keyframesName
   , khmer
   , kind
   , label

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -47,7 +47,7 @@ module Tecton.Internal
   , Inextensible
   , KeyframeBlock
   , Keyframes
-  , KeyframesName
+  , KeyframesName(..)
   , Length
   , LengthPercentage
   , LineName
@@ -554,7 +554,6 @@ module Tecton.Internal
   , katakanaIroha
   , keepAll
   , keyframes
-  , keyframesName
   , khmer
   , kind
   , label
@@ -1820,9 +1819,6 @@ instance
 newtype KeyframesName = KeyframesName String
 
 derive newtype instance ToVal KeyframesName
-
-keyframesName :: String -> KeyframesName
-keyframesName = KeyframesName
 
 newtype Keyframes = Keyframes KeyframesName
 

--- a/test/AnimationsSpec.purs
+++ b/test/AnimationsSpec.purs
@@ -6,7 +6,8 @@ import Prelude
 
 import Data.Tuple.Nested ((/\))
 import Tecton
-  ( all
+  ( KeyframesName(..)
+  , all
   , alternate
   , alternateReverse
   , animationDelay
@@ -34,7 +35,6 @@ import Tecton
   , jumpNone
   , jumpStart
   , keyframes
-  , keyframesName
   , linear
   , media
   , ms
@@ -72,19 +72,19 @@ spec =
 
       "@keyframes foo{0%{width:0}100%{width:500px}}"
         `isRenderedFrom` do
-          keyframes (keyframesName "foo") ? do
+          keyframes (KeyframesName "foo") ? do
             pct 0 ? width := nil
             pct 100 ? width := px 500
 
       "@media all{@keyframes foo{0%,100%{width:0}}}"
         `isRenderedFrom` do
           media all {} ? do
-            keyframes (keyframesName "foo") ? do
+            keyframes (KeyframesName "foo") ? do
               pct 0 /\ pct 100 ? width := nil
 
       "@keyframes foo{0%{width:75%}20%{width:80%}50%{width:100%}}"
         `isRenderedFrom` do
-          keyframes (keyframesName "foo") ? do
+          keyframes (KeyframesName "foo") ? do
             pct 0 ? width := pct 75
             pct 10 @+@ pct 5 @* 2 ? width := pct 80
             pct 100 @/ 2 ? width := pct 100
@@ -101,11 +101,11 @@ spec =
 
       "animation-name:none" `isRenderedFrom` (animationName := none)
 
-      "animation-name:xx" `isRenderedFrom` (animationName := keyframesName "xx")
+      "animation-name:xx" `isRenderedFrom` (animationName := KeyframesName "xx")
 
       "animation-name:foo,none,bar"
         `isRenderedFrom`
-          (animationName := keyframesName "foo" /\ none /\ keyframesName "bar")
+          (animationName := KeyframesName "foo" /\ none /\ KeyframesName "bar")
 
     describe "animation-duration property" do
 


### PR DESCRIPTION
### Description

This change drops the `keyframesName` function and exposes the `KeyframesName` constructor in its place.

### Design considerations

First, a little background: The `keyframesName` function was intended as a smart constructor "placeholder" of sorts. I got the idea that it might be important when I noticed that a [`<keyframes-name>` value](https://www.w3.org/TR/css-animations-1/#at-ruledef-keyframes) is a [`<custom-ident>`](https://www.w3.org/TR/css-values-4/#custom-idents) meaning that certain values aren't allowed, such as certain keywords. Although the function's signature `keyframesName :: String -> KeyframesName` didn't convey the notion of failure (e.g. through a `Maybe KeyframesName` return type), my high-level plan was to eventually add some logic to make any invalid `String` input into a valid `KeyframesName` value by changing the input in some way.

Now I am thinking this would likely involve a complicated implementation, likely an imperfect one, and probably doesn't offer enough benefit to justify that cost.

For comparison, I also had a look at Halogen, whose `ClassName` type (moved to [web-html](https://github.com/purescript-web/purescript-web-html) in 2020) is analogous to `KeyframesName`. Here's what I found:
* No smart constructor; the `ClassName` constructor is exposed instead. See [Web.HTML.Common](https://pursuit.purescript.org/packages/purescript-web-html/4.1.0/docs/Web.HTML.Common).
* There used to be a `className` constructor function, but [it was removed](https://github.com/garyb/purescript-halogen/commit/4519979b84a7ddcc47952152f49976bd0edd1711#diff-347f73cb84bc3f0e101a372f387b3e378d4df6b0a014cf51746110ace03847f3) many years ago without explanation.
* The aforementioned `className` function never included any validation or other logic to ensure that the `ClassName` return value would be a valid class name (e.g. free of whitespace). Perhaps this is why it was pruned.

Thus, in removing `keyframesName` I am following suit with the leading PureScript UI framework, whose core maintainers' judgment I trust, even if they didn't document their rationale in this case.

Moreover, I am considering (#29) adopting the `ClassName` and `AttrName` types (from [web-html](https://github.com/purescript-web/purescript-web-html), previously [halogen](https://github.com/purescript-halogen/purescript-halogen)). Since their constructors are exposed directly, I think the same pattern should be followed here for consistency's sake.

### Future plans

Revisit this issue if changes are made in `Web.HTML.Common`.

### References

* [`<keyframes-name>` type](https://www.w3.org/TR/css-animations-1/#at-ruledef-keyframes)
* [`<custom-ident>` type](https://www.w3.org/TR/css-values-4/#custom-idents)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [ ] I have added an entry to the _Unreleased_ section of the CHANGELOG.
