### PR TITLE
`#+` and `#-` operators to replace  (an+b) function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 - The `CustomAttribute` type and `att` constructor function have been removed in favor of the [`AttrName` type from `web-html`](https://pursuit.purescript.org/packages/purescript-web-html/4.1.0/docs/Web.HTML.Common#t:AttrName). nsaunders/purescript-tecton#35
 - The `&.` operator (`byClass` function) no longer accepts a string argument. Instead, it requires a [`ClassName`](https://pursuit.purescript.org/packages/purescript-web-html/4.1.0/docs/Web.HTML.Common#t:ClassName). nsaunders/purescript-tecton#35
 - The `&#` operator (`byId` function) no longer accepts a string argument. Instead, it requires a value of the newly-added `Identifier` type. nsaunders/purescript-tecton#35
+- The `nth` function has been dropped, replaced by the `#+` and `#-` operators that can be used to construct **a**_n_+**b** formulas. nsaunders/purescript-tecton#36 
 
 New features:
 - `box-sizing` property nsaunders/purescript-tecton#31

--- a/docs/how-to/selectors.md
+++ b/docs/how-to/selectors.md
@@ -255,7 +255,8 @@ Constructing these pseudo-classes in Tecton begins with the formula:
 
 - The `even` function will select even-numbered elements, equivalent to **2**_n_.
 - The `odd` function will select odd-numbered elements, equivalent to **2**_n_+**1**.
-- The `nth` function has two parameters **a** and **b** which are used to create a **a**_n_+**b** formula.
+- The `#+` operator has two parameters **a** and **b** which are used to create a **a**_n_+**b** formula, e.g. `2 #+ 1`.
+- The `#-` operator has two parameters **a** and **b** which are used to create a **a**_n_-**b** formula, e.g. `2 #- 1`.
 
 Apply one of the `nth*` functions listed above to the result to create the pseudo class.
 

--- a/examples/ZenGarments.purs
+++ b/examples/ZenGarments.purs
@@ -100,7 +100,6 @@ import Tecton
   , none
   , normal
   , nowrap
-  , nth
   , nthChild
   , odd
   , ol
@@ -154,6 +153,7 @@ import Tecton
   , visible
   , whiteSpace
   , width
+  , (#+)
   , (&.)
   , (&:)
   , (&::)
@@ -412,7 +412,7 @@ main = log $ renderSheet pretty do
       /\ universal &. ClassName "previous" |* a
       /\ universal &. ClassName "viewall" |* a
       /\ universal &. ClassName "zen-resources" |* a
-      /\ universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a
+      /\ universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a
   ) ? Rule.do
     transitionProperty := none
 
@@ -420,7 +420,7 @@ main = log $ renderSheet pretty do
       /\ universal &. ClassName "previous" |* a &:: after
       /\ universal &. ClassName "viewall" |* a &:: after
       /\ universal &. ClassName "zen-resources" |* a &:: after
-      /\ universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a &::
+      /\ universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a &::
         after
   ) ? Rule.do
     opacity := 0
@@ -768,14 +768,14 @@ main = log $ renderSheet pretty do
       transform := rotate $ deg (-90)
       maskImage := url "i/denim-mask2.png"
 
-    universal &. ClassName "summary" |* p &: nthChild (nth 0 2) ? Rule.do
+    universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) ? Rule.do
       backgroundColor := rgb 255 255 0
       position := relative
       visibility := hidden
       top := em 2
       fontSize := rem 1.4
 
-    universal &. ClassName "summary" |* p &: nthChild (nth 0 2) &:: before ?
+    universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) &:: before ?
       Rule.do
         content := ""
         display := block
@@ -790,7 +790,7 @@ main = log $ renderSheet pretty do
         width := em 6
         height := px 30
 
-    universal &. ClassName "summary" |* p &: nthChild (nth 0 2) &:: after ?
+    universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) &:: after ?
       Rule.do
         content := ""
         display := block
@@ -805,7 +805,7 @@ main = log $ renderSheet pretty do
         width := em 6
         height := px 30
 
-    universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a ? Rule.do
+    universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a ? Rule.do
       visibility := visible
       backgroundColor := transparent
       backgroundImage := url "s/czg.svg"
@@ -820,24 +820,24 @@ main = log $ renderSheet pretty do
       position := absolute
       top := nil
       right := em 7
-    ( universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a &: hover
-        /\ universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a &:
+    ( universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a &: hover
+        /\ universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a &:
           focus
     ) ? Rule.do
       backgroundPosition := px (-396) ~ px (-3)
       textIndent := nil
       backgroundImage := none
 
-    ( universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a &@ href
+    ( universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a &@ href
         *= "css"
     ) ? Rule.do
       backgroundPosition := px (-472) ~ px (-94)
       right := nil
-    ( universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a &@ href
+    ( universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a &@ href
         *= "css"
         &:
           hover
-        /\ universal &. ClassName "summary" |* p &: nthChild (nth 0 2) |* a
+        /\ universal &. ClassName "summary" |* p &: nthChild (0 #+ 2) |* a
           &@ href
           *= "css"
           &: focus

--- a/examples/output/ZenGarments.css
+++ b/examples/output/ZenGarments.css
@@ -303,7 +303,7 @@ sub, sup {
   margin: 0 0 1em;
   color: hsl(0.0, 0.0%, 66.67%);
 }
-*.design-selection li:nth-child(odd) {
+*.design-selection li:nth-child(2n + 1) {
   width: 47%;
   padding-right: 3%;
   clear: left;
@@ -629,7 +629,7 @@ footer a:first-child {
     margin-bottom: 3em;
     padding-right: 2%;
   }
-  *.design-selection li:nth-child(odd) {
+  *.design-selection li:nth-child(2n + 1) {
     width: 23%;
     clear: none;
     padding-right: 2%;

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -1,7 +1,8 @@
 module Tecton (module H, module T) where
 
 import Tecton.Internal
-  ( CSS
+  ( AnPlusB(..)
+  , CSS
   , Declarations
   , Identifier(..)
   , KeyframesName(..)
@@ -394,7 +395,6 @@ import Tecton.Internal
   , not
   , novalidate
   , nowrap
-  , nth
   , nthChild
   , nthLastChild
   , nthOfType
@@ -707,6 +707,8 @@ import Tecton.Internal
   , xxLarge
   , xxSmall
   , zIndex
+  , (#+)
+  , (#-)
   , ($=)
   , (&#)
   , (&.)

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -23,6 +23,8 @@ module Tecton.Internal
   , (|~)
   , (~)
   , (~=)
+  , (#-)
+  , (#+)
   , Add
   , Angle
   , AttributePredicate
@@ -59,7 +61,7 @@ module Tecton.Internal
   , Names
   , Nil
   , NoAuto
-  , Nth
+  , AnPlusB(..)
   , Orientation
   , Pair(..)
   , Percentage
@@ -106,6 +108,7 @@ module Tecton.Internal
   , animationName
   , animationPlayState
   , animationTimingFunction
+  , anminusb
   , appearance
   , arabicIndic
   , armenian
@@ -645,7 +648,6 @@ module Tecton.Internal
   , not
   , novalidate
   , nowrap
-  , nth
   , nthChild
   , nthLastChild
   , nthOfType
@@ -6106,12 +6108,10 @@ root = PseudoClass $ val "root"
 
 -- https://www.w3.org/TR/selectors-3/#sel-nth-child
 
-data Nth = Even | Odd | Nth Int Int
+data AnPlusB = AnPlusB Int Int
 
-instance ToVal Nth where
-  val Even = val "even"
-  val Odd = val "odd"
-  val (Nth a' b') =
+instance ToVal AnPlusB where
+  val (AnPlusB a' b') =
     Val \{ separator } ->
       let
         an
@@ -6130,26 +6130,30 @@ instance ToVal Nth where
       in
         an <> op <> b''
 
-even :: Nth
-even = Even
+even :: AnPlusB
+even = AnPlusB 2 0
 
-odd :: Nth
-odd = Odd
+odd :: AnPlusB
+odd = AnPlusB 2 1
 
-nth :: Int -> Int -> Nth
-nth = Nth
+infixl 9 AnPlusB as #+
 
-nthChild :: Nth -> PseudoClass
+anminusb :: Int -> Int -> AnPlusB
+anminusb a' b' = AnPlusB a' (-b')
+
+infixl 9 anminusb as #-
+
+nthChild :: AnPlusB -> PseudoClass
 nthChild formula = PseudoClass $ fn "nth-child" formula
 
 -- https://www.w3.org/TR/selectors-3/#sel-nth-last-child
 
-nthLastChild :: Nth -> PseudoClass
+nthLastChild :: AnPlusB -> PseudoClass
 nthLastChild formula = PseudoClass $ fn "nth-last-child" formula
 
 -- https://www.w3.org/TR/selectors-3/#sel-nth-of-type
 
-nthOfType :: Nth -> PseudoClass
+nthOfType :: AnPlusB -> PseudoClass
 nthOfType formula = PseudoClass $ fn "nth-of-type" formula
 
 -- https://www.w3.org/TR/selectors-3/#sel-first-child

--- a/test/SelectorsSpec.purs
+++ b/test/SelectorsSpec.purs
@@ -36,7 +36,6 @@ import Tecton
   , link
   , nil
   , not
-  , nth
   , nthChild
   , nthLastChild
   , nthOfType
@@ -52,6 +51,8 @@ import Tecton
   , universal
   , visited
   , width
+  , (#+)
+  , (#-)
   , ($=)
   , (&#)
   , (&.)
@@ -177,41 +178,41 @@ spec = do
 
       "*:root{width:0}" `isRenderedFrom` do universal &: root ? width := nil
 
-      "*:nth-child(even){width:0}"
+      "*:nth-child(2n){width:0}"
         `isRenderedFrom` do
           universal &: nthChild even ? width := nil
 
-      "*:nth-child(odd){width:0}"
+      "*:nth-child(2n+1){width:0}"
         `isRenderedFrom` do
           universal &: nthChild odd ? width := nil
 
       "*:nth-child(2n){width:0}"
         `isRenderedFrom` do
-          universal &: nthChild (nth 2 0) ? width := nil
+          universal &: nthChild (2 #+ 0) ? width := nil
 
       "*:nth-child(2n+1){width:0}"
         `isRenderedFrom` do
-          universal &: nthChild (nth 2 1) ? width := nil
+          universal &: nthChild (2 #+ 1) ? width := nil
 
       "*:nth-child(10n-1){width:0}"
         `isRenderedFrom` do
-          universal &: nthChild (nth 10 (-1)) ? width := nil
+          universal &: nthChild (10 #- 1) ? width := nil
 
       "*:nth-last-child(-n+2){width:0}"
         `isRenderedFrom` do
-          universal &: nthLastChild (nth (-1) 2) ? width := nil
+          universal &: nthLastChild ((-1) #+ 2) ? width := nil
 
-      "*:nth-last-child(odd){width:0}"
+      "*:nth-last-child(2n+1){width:0}"
         `isRenderedFrom` do
           universal &: nthLastChild odd ? width := nil
 
       "*:nth-of-type(2n+1){width:0}"
         `isRenderedFrom` do
-          universal &: nthOfType (nth 2 1) ? width := nil
+          universal &: nthOfType (2 #+ 1) ? width := nil
 
       "*:nth-of-type(2n){width:0}"
         `isRenderedFrom` do
-          universal &: nthOfType (nth 2 0) ? width := nil
+          universal &: nthOfType (2 #+ 0) ? width := nil
 
       "*:first-child{width:0}"
         `isRenderedFrom` do


### PR DESCRIPTION
### Description

* `Nth` type renamed to `AnPlusB` (inspired by csstree)
* `Even` and `Odd` constructors dropped in favor of a single `AnPlusB` constructor
* `nth` function replaced by the operators `#+` and `#-`
* `even` and `odd` functions just use `AnPlusB` constructor and are rendered as equivalent formulas (`2n` and `2n+1` respectively).

### Design considerations

1. `nthChild (nth 2 1)` is a bit repetitive and doesn't look much like the **a**_n_+**b** format. Therefore it might be unclear at first what the parameters represent.
2. Considering #1, I was going to rename the function to `anplusb` as I would have considered that to have stronger semantics than `nth`. But then I got the idea to add these operators instead.
3. Similarly the `Nth` data type is less clear than `AnPlusB`.
4. Removing the `Even` and `Odd` constructors was mostly just about simplifying things. But there is an incremental performance benefit also, in that `2n` and `2n+1` add up to 6 characters in total, while `even` and `odd` add up to 7 characters. Thus, the rendered output will be slightly more compact.

### Future plans

N/A

### References

* [AnPlusB (csstree AST)](https://github.com/csstree/csstree/blob/master/docs/ast.md#anplusb) (inspiration for type name)
* [:nth-child() - CSS: Cascading Style Sheets (MDN)](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#example_selectors) (shows `even` and `odd` formula equivalents)

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
