### PR TITLE
Add an "escape hatch" allowing unsafe declarations. Resolves #28.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ New features:
 - `box-sizing` property nsaunders/purescript-tecton#31
 - `word-break` property nsaunders/purescript-tecton#32
 - Support for custom pseudo-classes and pseudo-elements via the `PseudoClass` and `PseudoElement` constructors nsaunders/purescript-tecton#38
+- A new `unsafeDeclaration` function offers an "escape hatch" for e.g. vendor-prefixed or experimental properties that haven't been added to the library yet. nsaunders/purescript-tecton#40
 
 Bugfixes:
 - Fixed the content of the compiler error that results from duplicate properties or descriptors within a single ruleset. Previously all values were incorrectly reported as having the type `CommonKeyword`. nsaunders/purescript-tecton#39

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -677,6 +677,7 @@ import Tecton.Internal
   , underline
   , universal
   , unsafe
+  , unsafeDeclaration
   , unset
   , upperAlpha
   , upperArmenian

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -933,6 +933,7 @@ module Tecton.Internal
   , underline
   , universal
   , unsafe
+  , unsafeDeclaration
   , unset
   , upperAlpha
   , upperArmenian
@@ -1252,6 +1253,13 @@ instance
         Proxy
 
 infixr 0 assoc as :=
+
+-- | Adds a declaration to a rule. The first parameter is the name of the
+-- | property, while the second parameter is the corresponding value as it would
+-- | be written directly in CSS.
+unsafeDeclaration :: String -> String -> Writer (List Declaration') (Proxy ())
+unsafeDeclaration p' v' =
+  tell (pure $ Declaration' $ val p' /\ val v') *> pure Proxy
 
 concatDeclarations :: List (Val /\ Val) -> Val
 concatDeclarations decls = Val \c ->

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -31,6 +31,7 @@ import Test.TextSpec as Text
 import Test.TransformsSpec as Transforms
 import Test.TransitionsSpec as Transitions
 import Test.UISpec as UI
+import Test.UnsafeDeclarationSpec as UnsafeDeclaration
 import Test.VisufxSpec as Visufx
 import Test.VisurenSpec as Visuren
 import Test.WritingModesSpec as WritingModes
@@ -64,6 +65,7 @@ main =
       Transforms.spec
       Transitions.spec
       UI.spec
+      UnsafeDeclaration.spec
       Visufx.spec
       Visuren.spec
       WritingModes.spec

--- a/test/UnsafeDeclarationSpec.purs
+++ b/test/UnsafeDeclarationSpec.purs
@@ -1,0 +1,34 @@
+module Test.UnsafeDeclarationSpec where
+
+import Prelude
+
+import Tecton
+  ( KeyframesName(..)
+  , keyframes
+  , pct
+  , universal
+  , unsafeDeclaration
+  , (?)
+  )
+import Test.Spec (Spec, describe)
+import Test.Util (isRenderedFromSheet)
+
+spec :: Spec Unit
+spec = do
+
+  let isRenderedFrom = isRenderedFromSheet
+
+  describe "unsafeDeclaration" do
+
+    "*{-webkit-text-stroke-width:thin}"
+      `isRenderedFrom` do
+        universal ?
+          unsafeDeclaration "-webkit-text-stroke-width" "thin"
+
+    "@keyframes foo{0%{-moz-opacity:0}100%{-moz-opacity:1}}"
+      `isRenderedFrom` do
+        keyframes (KeyframesName "foo") ? do
+          pct 0 ?
+            unsafeDeclaration "-moz-opacity" "0"
+          pct 100 ?
+            unsafeDeclaration "-moz-opacity" "1"


### PR DESCRIPTION
### Description

This change adds a new `unsafeDeclaration` function that can be used within a ruleset to unsafely add a declaration. Useful for vendor-prefixed properties, or those that might be too new or experimental to have been added to this library yet.

### Design considerations

* There is no operator for this because I couldn't think of one that conveyed the notion of "unsafe".
* I considered implementing this with a signature of `unsafeDeclaration :: ToVal a => String -> a -> ...`, allowing users to write e.g. `unsafeDeclaration "--foo" 0` instead of `unsafeDeclaration "--foo" "0"`, but I decided against this because I don't want to make the API too friendly. Its use should generally be discouraged.

### Future plans

Make sure to stay on top of adding new CSS properties so that folks don't lean on this too heavily.

### References

Provide links to related issues, [W3C specifications](https://www.w3.org/TR/css-2021/), [MDN](http://developer.mozilla.org) articles, or other supporting resources.

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
