### PR TITLE
`cursor` property. Resolves #24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Breaking changes:
 
 New features:
 - `box-sizing` property nsaunders/purescript-tecton#31
+- `cursor` property nsaunders/purescript-tecton#41
 - `word-break` property nsaunders/purescript-tecton#32
 - Support for custom pseudo-classes and pseudo-elements via the `PseudoClass` and `PseudoElement` constructors nsaunders/purescript-tecton#38
 - A new `unsafeDeclaration` function offers an "escape hatch" for e.g. vendor-prefixed or experimental properties that haven't been added to the library yet. nsaunders/purescript-tecton#40

--- a/examples/type-errors/CursorMissingFallback.purs
+++ b/examples/type-errors/CursorMissingFallback.purs
@@ -1,0 +1,17 @@
+{-
+
+This example fails to compile because the value of the `cursor` property as
+defined in the Basic User Interface Module Level 4 specification requires the
+last entry to be a generic/native cursor rather than an image URL.
+
+See https://www.w3.org/TR/css-ui-4/#propdef-cursor for more information.
+
+-}
+
+module TypeError.CursorMissingFallback where
+
+import Data.Tuple.Nested ((/\))
+import Tecton (CSS, cursor, universal, url, (:=), (?))
+
+css :: CSS
+css = universal ? cursor := url "abc.png" /\ url "xyz.png"

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -19,11 +19,13 @@ import Tecton.Internal
   , active
   , adjacentSibling
   , after
+  , alias
   , alignContent
   , alignItems
   , alignSelf
   , alignmentBaseline
   , all
+  , allScroll
   , alphabetic
   , alt
   , alternate
@@ -103,6 +105,7 @@ import Tecton.Internal
   , canvas
   , capitalize
   , caption
+  , cell
   , center
   , central
   , ch
@@ -121,6 +124,7 @@ import Tecton.Internal
   , cm
   , code
   , col
+  , colResize
   , colgroup
   , collapse
   , collection
@@ -137,12 +141,16 @@ import Tecton.Internal
   , contentBox
   , contenteditable
   , contents
+  , contextMenu
   , controls
   , coords
+  , copy
   , cover
+  , crosshair
   , cubicBezier
   , currentColor
   , cursive
+  , cursor
   , dashed
   , data'
   , datetime
@@ -173,6 +181,7 @@ import Tecton.Internal
   , dpi
   , draggable
   , dt
+  , eResize
   , ease
   , easeIn
   , easeInOut
@@ -188,6 +197,7 @@ import Tecton.Internal
   , enctype
   , end
   , even
+  , ewResize
   , ex
   , expanded
   , extraCondensed
@@ -234,6 +244,8 @@ import Tecton.Internal
   , fullWidth
   , gap
   , georgian
+  , grab
+  , grabbing
   , grid
   , gridAutoColumns
   , gridAutoFlow
@@ -258,6 +270,7 @@ import Tecton.Internal
   , headers
   , hebrew
   , height
+  , help
   , hidden
   , high
   , hiragana
@@ -384,22 +397,31 @@ import Tecton.Internal
   , mm
   , mongolian
   , monospace
+  , move
   , ms
   , multiple
   , muted
   , myanmar
+  , nResize
   , name
   , nav
+  , neResize
+  , neswResize
   , nil
+  , noDrop
   , noRepeat
   , none
   , normal
   , not
+  , notAllowed
   , novalidate
   , nowrap
+  , nsResize
   , nthChild
   , nthLastChild
   , nthOfType
+  , nwResize
+  , nwseResize
   , oblique
   , odd
   , ol
@@ -508,6 +530,7 @@ import Tecton.Internal
   , persian
   , perspective
   , placeholder
+  , pointer
   , polygon
   , polyline
   , portrait
@@ -552,11 +575,13 @@ import Tecton.Internal
   , round
   , row
   , rowGap
+  , rowResize
   , rowReverse
   , rows
   , rowspan
   , rtl
   , running
+  , sResize
   , safe
   , sandbox
   , sansSerif
@@ -568,6 +593,7 @@ import Tecton.Internal
   , scope
   , screen
   , scroll
+  , seResize
   , sec
   , section
   , select
@@ -612,6 +638,7 @@ import Tecton.Internal
   , sup
   , super
   , svg
+  , swResize
   , systemUI
   , tabindex
   , table
@@ -628,6 +655,7 @@ import Tecton.Internal
   , tbody
   , td
   , telugu
+  , text
   , textAlign
   , textBottom
   , textDecorationColor
@@ -688,6 +716,7 @@ import Tecton.Internal
   , usemap
   , value
   , verticalAlign
+  , verticalText
   , vh
   , video
   , visibility
@@ -696,6 +725,8 @@ import Tecton.Internal
   , vmax
   , vmin
   , vw
+  , wResize
+  , wait
   , wavy
   , whiteSpace
   , width
@@ -710,6 +741,8 @@ import Tecton.Internal
   , xxLarge
   , xxSmall
   , zIndex
+  , zoomIn
+  , zoomOut
   , (#+)
   , (#-)
   , ($=)

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -242,6 +242,7 @@ module Tecton.Internal
   , class FontStretchKeyword
   , class FontStyleKeyword
   , class FontWeightKeyword
+  , class GenericCursorKeyword
   , class GenericFontFamilyKeyword
   , class IsAnimationNameList
   , class IsAttachmentList
@@ -258,6 +259,8 @@ module Tecton.Internal
   , class IsColor
   , class IsColorStopListHead
   , class IsColorStopListTail
+  , class IsCursorImage
+  , class IsCursorList
   , class IsExtensibleSelector
   , class IsFontFaceFontStyle
   , class IsFontFaceFontWeight
@@ -384,6 +387,7 @@ module Tecton.Internal
   , cubicBezier
   , currentColor
   , cursive
+  , cursor
   , dashed
   , data'
   , datetime
@@ -967,6 +971,38 @@ module Tecton.Internal
   , xxLarge
   , xxSmall
   , zIndex
+  , contextMenu
+  , help
+  , pointer
+  , wait
+  , cell
+  , crosshair
+  , text
+  , verticalText
+  , alias
+  , copy
+  , move
+  , noDrop
+  , notAllowed
+  , grab
+  , grabbing
+  , eResize
+  , nResize
+  , neResize
+  , nwResize
+  , sResize
+  , seResize
+  , swResize
+  , wResize
+  , ewResize
+  , nsResize
+  , neswResize
+  , nwseResize
+  , colResize
+  , rowResize
+  , allScroll
+  , zoomIn
+  , zoomOut
   ) where
 
 import Prelude hiding (add, bottom, sub, top)
@@ -7130,6 +7166,101 @@ instance declarationOutlineOffset ::
   Declaration "outline-offset" (Measure t) where
   pval = const val
 
+-- https://www.w3.org/TR/css-ui-4/#propdef-cursor
+
+cursor = Proxy :: Proxy "cursor"
+
+instance Property "cursor"
+
+contextMenu = Proxy :: Proxy "context-menu"
+help = Proxy :: Proxy "help"
+pointer = Proxy :: Proxy "pointer"
+wait = Proxy :: Proxy "wait"
+cell = Proxy :: Proxy "cell"
+crosshair = Proxy :: Proxy "crosshair"
+text = Proxy :: Proxy "text"
+verticalText = Proxy :: Proxy "vertical-text"
+alias = Proxy :: Proxy "alias"
+copy = Proxy :: Proxy "copy"
+move = Proxy :: Proxy "move"
+noDrop = Proxy :: Proxy "no-drop"
+notAllowed = Proxy :: Proxy "not-allowed"
+grab = Proxy :: Proxy "grab"
+grabbing = Proxy :: Proxy "grabbing"
+eResize = Proxy :: Proxy "e-resize"
+nResize = Proxy :: Proxy "n-resize"
+neResize = Proxy :: Proxy "ne-resize"
+nwResize = Proxy :: Proxy "nw-resize"
+sResize = Proxy :: Proxy "s-resize"
+seResize = Proxy :: Proxy "se-resize"
+swResize = Proxy :: Proxy "sw-resize"
+wResize = Proxy :: Proxy "w-resize"
+ewResize = Proxy :: Proxy "ew-resize"
+nsResize = Proxy :: Proxy "ns-resize"
+neswResize = Proxy :: Proxy "nesw-resize"
+nwseResize = Proxy :: Proxy "nwse-resize"
+colResize = Proxy :: Proxy "col-resize"
+rowResize = Proxy :: Proxy "row-resize"
+allScroll = Proxy :: Proxy "all-scroll"
+zoomIn = Proxy :: Proxy "zoom-in"
+zoomOut = Proxy :: Proxy "zoom-out"
+
+class GenericCursorKeyword (s :: Symbol)
+
+instance GenericCursorKeyword "auto"
+instance GenericCursorKeyword "default"
+instance GenericCursorKeyword "none"
+instance GenericCursorKeyword "context-menu"
+instance GenericCursorKeyword "help"
+instance GenericCursorKeyword "pointer"
+instance GenericCursorKeyword "progress"
+instance GenericCursorKeyword "wait"
+instance GenericCursorKeyword "cell"
+instance GenericCursorKeyword "crosshair"
+instance GenericCursorKeyword "text"
+instance GenericCursorKeyword "vertical-text"
+instance GenericCursorKeyword "alias"
+instance GenericCursorKeyword "copy"
+instance GenericCursorKeyword "move"
+instance GenericCursorKeyword "no-drop"
+instance GenericCursorKeyword "not-allowed"
+instance GenericCursorKeyword "grab"
+instance GenericCursorKeyword "grabbing"
+instance GenericCursorKeyword "e-resize"
+instance GenericCursorKeyword "n-resize"
+instance GenericCursorKeyword "ne-resize"
+instance GenericCursorKeyword "nw-resize"
+instance GenericCursorKeyword "s-resize"
+instance GenericCursorKeyword "se-resize"
+instance GenericCursorKeyword "sw-resize"
+instance GenericCursorKeyword "w-resize"
+instance GenericCursorKeyword "ew-resize"
+instance GenericCursorKeyword "ns-resize"
+instance GenericCursorKeyword "nesw-resize"
+instance GenericCursorKeyword "nwse-resize"
+instance GenericCursorKeyword "col-resize"
+instance GenericCursorKeyword "row-resize"
+instance GenericCursorKeyword "all-scroll"
+instance GenericCursorKeyword "zoom-in"
+instance GenericCursorKeyword "zoom-out"
+
+class IsCursorImage (a :: Type)
+
+instance IsCursorImage URL
+instance IsCursorImage (URL ~ Int ~ Int)
+
+class IsCursorList (a :: Type)
+
+instance GenericCursorKeyword s => IsCursorList (Proxy s)
+instance (IsCursorImage x, IsCursorList xs) => IsCursorList (x /\ xs)
+
+instance declarationCursor ::
+  ( IsCursorList xs
+  , MultiVal xs
+  ) =>
+  Declaration "cursor" xs where
+  pval = const $ intercalateMultiVal (val "," <> Val _.separator)
+
 -- https://www.w3.org/TR/css-ui-4/#propdef-appearance
 
 appearance = Proxy :: Proxy "appearance"
@@ -7148,7 +7279,7 @@ instance AppearanceKeyword "menulist-button"
 
 instance declarationAppearance ::
   ( AppearanceKeyword s
-  , IsSymbol s
+  , ToVal (Proxy s)
   ) =>
   Declaration "appearance" (Proxy s) where
   pval = const val

--- a/test/UISpec.purs
+++ b/test/UISpec.purs
@@ -5,35 +5,73 @@ module Test.UISpec where
 import Prelude
 
 import Color (rgb)
+import Data.Tuple.Nested ((/\))
 import Tecton
-  ( appearance
+  ( alias
+  , allScroll
+  , appearance
   , auto
+  , cell
+  , colResize
+  , contextMenu
+  , copy
+  , crosshair
+  , cursor
   , dashed
+  , default
   , dotted
   , double
+  , eResize
+  , ewResize
+  , grab
+  , grabbing
   , groove
+  , help
   , inherit
   , initial
   , inset
   , invert
   , medium
   , menulistButton
+  , move
+  , nResize
+  , neResize
+  , neswResize
   , nil
+  , noDrop
   , none
+  , notAllowed
+  , nsResize
+  , nwResize
+  , nwseResize
   , outlineColor
   , outlineOffset
   , outlineStyle
   , outlineWidth
   , outset
+  , pointer
+  , progress
   , px
   , ridge
+  , rowResize
+  , sResize
+  , seResize
   , solid
+  , swResize
+  , text
   , textfield
   , thick
   , thin
   , transparent
   , unset
+  , url
+  , verticalText
+  , wResize
+  , wait
+  , zoomIn
+  , zoomOut
   , (:=)
+  , (~)
   )
 import Test.Spec (Spec, describe)
 import Test.Util (isRenderedFromInline)
@@ -114,6 +152,95 @@ spec = do
       "outline-offset:4px" `isRenderedFrom` (outlineOffset := px 4)
 
       "outline-offset:0" `isRenderedFrom` (outlineOffset := nil)
+
+    describe "cursor" do
+
+      "cursor:inherit" `isRenderedFrom` (cursor := inherit)
+
+      "cursor:initial" `isRenderedFrom` (cursor := initial)
+
+      "cursor:unset" `isRenderedFrom` (cursor := unset)
+
+      "cursor:auto" `isRenderedFrom` (cursor := auto)
+
+      "cursor:default" `isRenderedFrom` (cursor := default)
+
+      "cursor:none" `isRenderedFrom` (cursor := none)
+
+      "cursor:context-menu" `isRenderedFrom` (cursor := contextMenu)
+
+      "cursor:help" `isRenderedFrom` (cursor := help)
+
+      "cursor:pointer" `isRenderedFrom` (cursor := pointer)
+
+      "cursor:progress" `isRenderedFrom` (cursor := progress)
+
+      "cursor:wait" `isRenderedFrom` (cursor := wait)
+
+      "cursor:cell" `isRenderedFrom` (cursor := cell)
+
+      "cursor:crosshair" `isRenderedFrom` (cursor := crosshair)
+
+      "cursor:text" `isRenderedFrom` (cursor := text)
+
+      "cursor:vertical-text" `isRenderedFrom` (cursor := verticalText)
+
+      "cursor:alias" `isRenderedFrom` (cursor := alias)
+
+      "cursor:copy" `isRenderedFrom` (cursor := copy)
+
+      "cursor:move" `isRenderedFrom` (cursor := move)
+
+      "cursor:no-drop" `isRenderedFrom` (cursor := noDrop)
+
+      "cursor:not-allowed" `isRenderedFrom` (cursor := notAllowed)
+
+      "cursor:grab" `isRenderedFrom` (cursor := grab)
+
+      "cursor:grabbing" `isRenderedFrom` (cursor := grabbing)
+
+      "cursor:e-resize" `isRenderedFrom` (cursor := eResize)
+
+      "cursor:n-resize" `isRenderedFrom` (cursor := nResize)
+
+      "cursor:ne-resize" `isRenderedFrom` (cursor := neResize)
+
+      "cursor:nw-resize" `isRenderedFrom` (cursor := nwResize)
+
+      "cursor:s-resize" `isRenderedFrom` (cursor := sResize)
+
+      "cursor:se-resize" `isRenderedFrom` (cursor := seResize)
+
+      "cursor:sw-resize" `isRenderedFrom` (cursor := swResize)
+
+      "cursor:w-resize" `isRenderedFrom` (cursor := wResize)
+
+      "cursor:ew-resize" `isRenderedFrom` (cursor := ewResize)
+
+      "cursor:ns-resize" `isRenderedFrom` (cursor := nsResize)
+
+      "cursor:nesw-resize" `isRenderedFrom` (cursor := neswResize)
+
+      "cursor:nwse-resize" `isRenderedFrom` (cursor := nwseResize)
+
+      "cursor:col-resize" `isRenderedFrom` (cursor := colResize)
+
+      "cursor:row-resize" `isRenderedFrom` (cursor := rowResize)
+
+      "cursor:all-scroll" `isRenderedFrom` (cursor := allScroll)
+
+      "cursor:zoom-in" `isRenderedFrom` (cursor := zoomIn)
+
+      "cursor:zoom-out" `isRenderedFrom` (cursor := zoomOut)
+
+      "cursor:url(\"example.svg#linkcursor\"),url(\"hyper.cur\"),url(\"hyper.png\") 2 3,pointer"
+        `isRenderedFrom`
+          ( cursor := url "example.svg#linkcursor" /\ url "hyper.cur"
+              /\ url "hyper.png"
+                ~ 2
+                ~ 3
+              /\ pointer
+          )
 
     describe "appearance property" do
 


### PR DESCRIPTION
### Description

This change adds support for the `cursor` property.

### Design considerations

Although the [image cursors](https://www.w3.org/TR/css-ui-4/#cursors) portion of the spec suggests some UAs might support the full range of `<image>` values, I don't find this to be the case in the real world; and that is why this implementation is limited to the `<url>` subset of `<image>`.

### Future plans

N/A

### References

* [CSS Basic User Interface Module Level 4: The 'cursor' property (W3C)](https://w3.org/TR/css-ui-4/#propdef-cursor)
* Resolves #24 

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
