### PR TITLE
Deprecate `lineName` function in favor of `LineName` constructor. Resolves #42.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes are documented in this file. The format is based on [Keep a Chan
 Breaking changes:
 
 New features:
+- The `LineName` data constructor is now exported, replacing the `lineName` function which is hereby deprecated. nsaunders/purescript-tecton#43
 
 Bugfixes:
 

--- a/src/Tecton.purs
+++ b/src/Tecton.purs
@@ -6,6 +6,7 @@ import Tecton.Internal
   , Declarations
   , ElementId(..)
   , KeyframesName(..)
+  , LineName(..)
   , PseudoClass(PseudoClass)
   , PseudoElement(PseudoElement)
   , a

--- a/src/Tecton/Internal.purs
+++ b/src/Tecton/Internal.purs
@@ -53,7 +53,7 @@ module Tecton.Internal
   , KeyframesName(..)
   , Length
   , LengthPercentage
-  , LineName
+  , LineName(..)
   , LocalFunction
   , Measure
   , MediaQuery
@@ -1027,6 +1027,7 @@ import Data.Tuple.Nested (type (/\), (/\))
 import Prim.Row as Row
 import Prim.RowList (class RowToList, RowList)
 import Prim.RowList as RL
+import Prim.TypeError (class Warn, Text)
 import Record as Record
 import Type.Proxy (Proxy(..))
 import Web.HTML.Common (AttrName(..), ClassName(..))
@@ -3938,7 +3939,7 @@ newtype LineName = LineName String
 
 derive newtype instance ToVal LineName
 
-lineName :: String -> LineName
+lineName :: Warn (Text "`lineName` is deprecated. Use the `LineName` constructor instead.") => String -> LineName
 lineName = LineName
 
 instance ToVal (List LineName) where

--- a/test/GridSpec.purs
+++ b/test/GridSpec.purs
@@ -6,7 +6,8 @@ import Prelude
 
 import Data.Tuple.Nested ((/\))
 import Tecton
-  ( auto
+  ( LineName(..)
+  , auto
   , autoFill
   , autoFit
   , column
@@ -25,7 +26,6 @@ import Tecton
   , gridTemplateRows
   , inherit
   , initial
-  , lineName
   , maxContent
   , minContent
   , minmax
@@ -72,10 +72,10 @@ spec = do
       "grid-template-columns:[attend settle] repeat(3,[document-festival] fit-content(421.3px) auto fit-content(399.6px))"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "attend"
-              /\ lineName "settle"
+              LineName "attend"
+              /\ LineName "settle"
               /\ repeat 3
-                ( lineName "document-festival"
+                ( LineName "document-festival"
                     /\ fitContent (px 421.3)
                     /\ auto
                     /\ fitContent (px 399.6)
@@ -88,7 +88,7 @@ spec = do
               repeat autoFit
                 ( pct 53.1
                     /\ minmax (px 138.5) auto
-                    /\ lineName "resist"
+                    /\ LineName "resist"
                 )
               /\ minmax (pct 6.1) maxContent
           )
@@ -100,19 +100,19 @@ spec = do
                 ( px 21.4
                     /\ pct 90.5
                 )
-              /\ lineName "despair-stage"
-              /\ lineName "join-burden"
-              /\ lineName "true-genius"
+              /\ LineName "despair-stage"
+              /\ LineName "join-burden"
+              /\ LineName "true-genius"
           )
 
       "grid-template-columns:repeat(3,[leg] minmax(max-content,475px) max-content [mutual])"
         `isRenderedFrom`
           ( gridTemplateColumns :=
               repeat 3
-                ( lineName "leg"
+                ( LineName "leg"
                     /\ minmax maxContent (px 475)
                     /\ maxContent
-                    /\ lineName "mutual"
+                    /\ LineName "mutual"
                 )
           )
 
@@ -120,20 +120,20 @@ spec = do
         `isRenderedFrom`
           ( gridTemplateColumns :=
               pct 21
-              /\ lineName "tobacco"
-              /\ lineName "mandate"
+              /\ LineName "tobacco"
+              /\ LineName "mandate"
               /\ repeat autoFill
                 ( minmax (vw 172.8) maxContent
                     /\ pct 60.7
                     /\ vw 384.7
                 )
-              /\ lineName "wide"
+              /\ LineName "wide"
           )
 
       "grid-template-columns:[also] 27.8% repeat(auto-fill,minmax(29.5%,13.8%) minmax(76.2%,2fr))"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "also"
+              LineName "also"
               /\ pct 27.8
               /\ repeat autoFill
                 ( minmax (pct 29.5) (pct 13.8)
@@ -151,8 +151,8 @@ spec = do
               repeat 5
                 ( auto
                     /\ minmax minContent maxContent
-                    /\ lineName "afraid-pony"
-                    /\ lineName "ask-group"
+                    /\ LineName "afraid-pony"
+                    /\ LineName "ask-group"
                 )
           )
 
@@ -163,31 +163,31 @@ spec = do
       "grid-template-columns:repeat(auto-fill,[family] 453.2vw 76.2%) repeat(1,minmax(121.1px,2fr) 329.5vw 67.2%)"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              repeat autoFill (lineName "family" /\ vw 453.2 /\ pct 76.2)
+              repeat autoFill (LineName "family" /\ vw 453.2 /\ pct 76.2)
               /\ repeat 1 (minmax (px 121.1) (fr 2) /\ vw 329.5 /\ pct 67.2)
           )
 
       "grid-template-columns:[arrive] minmax(max-content,1.7fr) [repeat-emerge]"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "arrive"
+              LineName "arrive"
               /\ minmax maxContent (fr 1.7)
-              /\ lineName "repeat-emerge"
+              /\ LineName "repeat-emerge"
           )
 
       "grid-template-columns:[theme-aim argue-master] repeat(auto-fill,25.2% minmax(11%,1.8fr) [rigid-immense]) [wife ahead option-purpose]"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "theme-aim"
-              /\ lineName "argue-master"
+              LineName "theme-aim"
+              /\ LineName "argue-master"
               /\ repeat autoFill
                 ( pct 25.2
                     /\ minmax (pct 11) (fr 1.8)
-                    /\ lineName "rigid-immense"
+                    /\ LineName "rigid-immense"
                 )
-              /\ lineName "wife"
-              /\ lineName "ahead"
-              /\ lineName "option-purpose"
+              /\ LineName "wife"
+              /\ LineName "ahead"
+              /\ LineName "option-purpose"
           )
 
       "grid-template-columns:repeat(auto-fill,minmax(38%,min-content) 467vw)"
@@ -220,41 +220,41 @@ spec = do
       "grid-template-columns:[pass] repeat(1,[foot-battle brother trick-category] fit-content(21.5em) minmax(min-content,min-content) [salad])"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "pass"
+              LineName "pass"
               /\ repeat 1
-                ( lineName "foot-battle"
-                    /\ lineName "brother"
-                    /\ lineName "trick-category"
+                ( LineName "foot-battle"
+                    /\ LineName "brother"
+                    /\ LineName "trick-category"
                     /\ fitContent (em 21.5)
                     /\ minmax minContent minContent
-                    /\ lineName "salad"
+                    /\ LineName "salad"
                 )
           )
 
       "grid-template-columns:[replace-another] repeat(4,[inmate valley believe] minmax(auto,2.5fr) fit-content(26%) [find])"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "replace-another"
+              LineName "replace-another"
               /\ repeat 4
-                ( lineName "inmate"
-                    /\ lineName "valley"
-                    /\ lineName "believe"
+                ( LineName "inmate"
+                    /\ LineName "valley"
+                    /\ LineName "believe"
                     /\ minmax auto (fr 2.5)
                     /\ fitContent (pct 26)
-                    /\ lineName "find"
+                    /\ LineName "find"
                 )
           )
 
       "grid-template-columns:repeat(auto-fill,[mask] 76.5% 191vw 17em)"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              repeat autoFill $ lineName "mask" /\ pct 76.5 /\ vw 191 /\ em 17
+              repeat autoFill $ LineName "mask" /\ pct 76.5 /\ vw 191 /\ em 17
           )
 
       "grid-template-columns:[shoulder-flavor] repeat(2,1.2fr fit-content(187.1em))"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "shoulder-flavor"
+              LineName "shoulder-flavor"
               /\ repeat 2 (fr 1.2 /\ fitContent (em 187.1))
           )
 
@@ -268,7 +268,7 @@ spec = do
         `isRenderedFrom`
           ( gridTemplateColumns :=
               repeat 2
-                ( lineName "fetch-silent"
+                ( LineName "fetch-silent"
                     /\ minmax (pct 24.2) (pct 28)
                     /\ minmax auto minContent
                 )
@@ -281,17 +281,17 @@ spec = do
       "grid-template-columns:[spot] repeat(4,[idea-forum] 80% fit-content(55vw))"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "spot"
+              LineName "spot"
               /\ repeat 4
-                (lineName "idea-forum" /\ pct 80 /\ fitContent (vw 55))
+                (LineName "idea-forum" /\ pct 80 /\ fitContent (vw 55))
           )
 
       "grid-template-columns:[salmon-crop among parent] repeat(auto-fill,446.1px 310.9px)"
         `isRenderedFrom`
           ( gridTemplateColumns :=
-              lineName "salmon-crop"
-              /\ lineName "among"
-              /\ lineName "parent"
+              LineName "salmon-crop"
+              /\ LineName "among"
+              /\ LineName "parent"
               /\ repeat autoFill (px 446.1 /\ px 310.9)
           )
 
@@ -316,17 +316,17 @@ spec = do
       "grid-template-rows:[only helmet-exchange] 80.1% repeat(2,[online] minmax(24.6vw,358.9vw) minmax(55%,auto) minmax(92.3%,auto)) repeat(auto-fill,96.2% 20.7% [history]) repeat(2,minmax(75%,auto) [sock-dutch]) repeat(2,259em 11.9%)"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              lineName "only"
-              /\ lineName "helmet-exchange"
+              LineName "only"
+              /\ LineName "helmet-exchange"
               /\ pct 80.1
               /\ repeat 2
-                ( lineName "online"
+                ( LineName "online"
                     /\ minmax (vw 24.6) (vw 358.9)
                     /\ minmax (pct 55) auto
                     /\ minmax (pct 92.3) auto
                 )
-              /\ repeat autoFill (pct 96.2 /\ pct 20.7 /\ lineName "history")
-              /\ repeat 2 (minmax (pct 75) auto /\ lineName "sock-dutch")
+              /\ repeat autoFill (pct 96.2 /\ pct 20.7 /\ LineName "history")
+              /\ repeat 2 (minmax (pct 75) auto /\ LineName "sock-dutch")
               /\ repeat 2 (em 259 /\ pct 11.9)
           )
 
@@ -334,26 +334,26 @@ spec = do
         `isRenderedFrom`
           ( gridTemplateRows :=
               minmax (em 396) maxContent
-              /\ repeat autoFill (em 354.8 /\ lineName "crash")
-              /\ lineName "melt"
-              /\ lineName "chief"
+              /\ repeat autoFill (em 354.8 /\ LineName "crash")
+              /\ LineName "melt"
+              /\ LineName "chief"
           )
 
       "grid-template-rows:repeat(2,minmax(69.7%,auto) minmax(169.6px,2fr)) [square copper-venture] repeat(auto-fill,[device-banana] 15% minmax(57%,auto) [tiger-desk legal-sign stereo-rocket]) [giant-kid]"
         `isRenderedFrom`
           ( gridTemplateRows :=
               repeat 2 (minmax (pct 69.7) auto /\ minmax (px 169.6) (fr 2))
-              /\ lineName "square"
-              /\ lineName "copper-venture"
+              /\ LineName "square"
+              /\ LineName "copper-venture"
               /\ repeat autoFill
-                ( lineName "device-banana"
+                ( LineName "device-banana"
                     /\ pct 15
                     /\ minmax (pct 57) auto
-                    /\ lineName "tiger-desk"
-                    /\ lineName "legal-sign"
-                    /\ lineName "stereo-rocket"
+                    /\ LineName "tiger-desk"
+                    /\ LineName "legal-sign"
+                    /\ LineName "stereo-rocket"
                 )
-              /\ lineName "giant-kid"
+              /\ LineName "giant-kid"
           )
 
       "grid-template-rows:minmax(max-content,2fr)"
@@ -363,7 +363,7 @@ spec = do
       "grid-template-rows:repeat(1,477vw 7.2% [dumb-anger]) repeat(auto-fit,297.5px minmax(43.3%,auto))"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              repeat 1 (vw 477 /\ pct 7.2 /\ lineName "dumb-anger")
+              repeat 1 (vw 477 /\ pct 7.2 /\ LineName "dumb-anger")
               /\ repeat autoFit (px 297.5 /\ minmax (pct 43.3) auto)
           )
 
@@ -374,11 +374,11 @@ spec = do
       "grid-template-rows:repeat(3,minmax(31.4%,auto) [stable-small]) repeat(auto-fit,minmax(40.8%,max-content) minmax(129.6vw,154px) [noble]) minmax(447.9px,min-content)"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              repeat 3 (minmax (pct 31.4) auto /\ lineName "stable-small")
+              repeat 3 (minmax (pct 31.4) auto /\ LineName "stable-small")
               /\ repeat autoFit
                 ( minmax (pct 40.8) maxContent
                     /\ minmax (vw 129.6) (px 154)
-                    /\ lineName "noble"
+                    /\ LineName "noble"
                 )
               /\ minmax (px 447.9) minContent
           )
@@ -393,11 +393,11 @@ spec = do
               minmax (pct 54) (pct 40.4)
               /\ repeat 1 (em 378.4 /\ minmax (pct 40.9) maxContent)
               /\ repeat autoFill
-                ( lineName "inner-uphold"
+                ( LineName "inner-uphold"
                     /\ minmax (px 450.8) auto
                     /\ minmax (em 96.1) (fr 1.9)
                 )
-              /\ lineName "usual-brave"
+              /\ LineName "usual-brave"
               /\ repeat 2 (minmax (em 456.8) maxContent /\ px 127.6)
               /\ repeat 1 (vw 184 /\ pct 11.9)
           )
@@ -405,9 +405,9 @@ spec = do
       "grid-template-rows:[spirit-dawn either deliver] repeat(auto-fill,minmax(38.1%,auto) 434em) repeat(1,minmax(482.1em,24.9%) minmax(90.7%,min-content)) minmax(358.2px,max-content)"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              lineName "spirit-dawn"
-              /\ lineName "either"
-              /\ lineName "deliver"
+              LineName "spirit-dawn"
+              /\ LineName "either"
+              /\ LineName "deliver"
               /\ repeat autoFill (minmax (pct 38.1) auto /\ em 434)
               /\ repeat 1
                 ( minmax (em 482.1) (pct 24.9)
@@ -433,17 +433,17 @@ spec = do
                 ( pct 67.1
                     /\ pct 75
                     /\ minmax (pct 95) minContent
-                    /\ lineName "unlock-already"
-                    /\ lineName "luggage"
+                    /\ LineName "unlock-already"
+                    /\ LineName "luggage"
                 )
-              /\ lineName "grocery-father"
+              /\ LineName "grocery-father"
           )
 
       "grid-template-rows:repeat(5,[toward-crystal] minmax(min-content,94.4%) fit-content(216.5vw) minmax(min-content,30.1%))"
         `isRenderedFrom`
           ( gridTemplateRows :=
               repeat 5
-                ( lineName "toward-crystal"
+                ( LineName "toward-crystal"
                     /\ minmax minContent (pct 94.4)
                     /\ fitContent (vw 216.5)
                     /\ minmax minContent (pct 30.1)
@@ -463,13 +463,13 @@ spec = do
       "grid-template-rows:[shove] repeat(1,minmax(max-content,min-content) minmax(auto,336.2vw) [habit-type cool-bronze melody-trip])"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              lineName "shove"
+              LineName "shove"
               /\ repeat 1
                 ( minmax maxContent minContent
                     /\ minmax auto (vw 336.2)
-                    /\ lineName "habit-type"
-                    /\ lineName "cool-bronze"
-                    /\ lineName "melody-trip"
+                    /\ LineName "habit-type"
+                    /\ LineName "cool-bronze"
+                    /\ LineName "melody-trip"
                 )
           )
 
@@ -481,17 +481,17 @@ spec = do
               /\ repeat autoFit
                 ( minmax (em 182.7) minContent
                     /\ em 442.4
-                    /\ lineName "unhappy"
-                    /\ lineName "aunt"
-                    /\ lineName "sunny"
+                    /\ LineName "unhappy"
+                    /\ LineName "aunt"
+                    /\ LineName "sunny"
                 )
           )
 
       "grid-template-rows:[wedding-impose gloom] repeat(auto-fill,176.1px 483.8vw minmax(48.5%,auto))"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              lineName "wedding-impose"
-              /\ lineName "gloom"
+              LineName "wedding-impose"
+              /\ LineName "gloom"
               /\ repeat autoFill
                 ( px 176.1
                     /\ vw 483.8
@@ -503,9 +503,9 @@ spec = do
         `isRenderedFrom`
           ( gridTemplateRows :=
               repeat autoFill (vw 33.5)
-              /\ lineName "garlic"
-              /\ lineName "potato"
-              /\ lineName "drill"
+              /\ LineName "garlic"
+              /\ LineName "potato"
+              /\ LineName "drill"
           )
 
       "grid-template-rows:42% 52.3% repeat(auto-fit,52.6% [syrup]) 36.2% minmax(36.6%,auto) [fever]"
@@ -513,10 +513,10 @@ spec = do
           ( gridTemplateRows :=
               pct 42
               /\ pct 52.3
-              /\ repeat autoFit (pct 52.6 /\ lineName "syrup")
+              /\ repeat autoFit (pct 52.6 /\ LineName "syrup")
               /\ pct 36.2
               /\ minmax (pct 36.6) auto
-              /\ lineName "fever"
+              /\ LineName "fever"
           )
 
       "grid-template-rows:max-content"
@@ -529,16 +529,16 @@ spec = do
               repeat 5
                 ( fitContent (pct 92.4)
                     /\ pct 55.7
-                    /\ lineName "stomach-myself"
+                    /\ LineName "stomach-myself"
                 )
           )
 
       "grid-template-rows:[arch-smoke harvest link-common] repeat(2,minmax(max-content,51vw) auto fit-content(70.1%))"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              lineName "arch-smoke"
-              /\ lineName "harvest"
-              /\ lineName "link-common"
+              LineName "arch-smoke"
+              /\ LineName "harvest"
+              /\ LineName "link-common"
               /\ repeat 2
                 ( minmax maxContent (vw 51)
                     /\ auto
@@ -552,29 +552,29 @@ spec = do
               repeat autoFill (minmax (pct 89.1) (px 55.3))
               /\ minmax (pct 86.9) (fr 1.1)
               /\ minmax (px 224.8) auto
-              /\ lineName "dose-spatial"
+              /\ LineName "dose-spatial"
           )
 
       "grid-template-rows:repeat(3,[trap] minmax(400.1vw,244.6px) 58em minmax(69.2%,max-content)) repeat(3,419em 47%) repeat(auto-fill,[expose-focus curious-coconut stone-cigar] 54.3% minmax(9.6%,max-content) minmax(69%,119.4vw)) repeat(2,[buyer-stage] minmax(7%,9.6%) 62.8%)"
         `isRenderedFrom`
           ( gridTemplateRows :=
               repeat 3
-                ( lineName "trap"
+                ( LineName "trap"
                     /\ minmax (vw 400.1) (px 244.6)
                     /\ em 58
                     /\ minmax (pct 69.2) maxContent
                 )
               /\ repeat 3 (em 419 /\ pct 47)
               /\ repeat autoFill
-                ( lineName "expose-focus"
-                    /\ lineName "curious-coconut"
-                    /\ lineName "stone-cigar"
+                ( LineName "expose-focus"
+                    /\ LineName "curious-coconut"
+                    /\ LineName "stone-cigar"
                     /\ pct 54.3
                     /\ minmax (pct 9.6) maxContent
                     /\ minmax (pct 69) (vw 119.4)
                 )
               /\ repeat 2
-                ( lineName "buyer-stage"
+                ( LineName "buyer-stage"
                     /\ minmax (pct 7) (pct 9.6)
                     /\ pct 62.8
                 )
@@ -583,13 +583,13 @@ spec = do
       "grid-template-rows:[lottery omit-hockey] repeat(auto-fill,minmax(15.4%,min-content) minmax(492vw,max-content) 498.6px [taxi]) repeat(2,minmax(89.6%,65vw))"
         `isRenderedFrom`
           ( gridTemplateRows :=
-              lineName "lottery"
-              /\ lineName "omit-hockey"
+              LineName "lottery"
+              /\ LineName "omit-hockey"
               /\ repeat autoFill
                 ( minmax (pct 15.4) minContent
                     /\ minmax (vw 492) maxContent
                     /\ px 498.6
-                    /\ lineName "taxi"
+                    /\ LineName "taxi"
                 )
               /\ repeat 2 (minmax (pct 89.6) (vw 65))
           )
@@ -764,23 +764,23 @@ spec = do
 
       "grid-row-start:auto" `isRenderedFrom` (gridRowStart := auto)
 
-      "grid-row-start:sugar" `isRenderedFrom` (gridRowStart := lineName "sugar")
+      "grid-row-start:sugar" `isRenderedFrom` (gridRowStart := LineName "sugar")
 
       "grid-row-start:1" `isRenderedFrom` (gridRowStart := 1)
 
       "grid-row-start:-1 design"
         `isRenderedFrom`
-          (gridRowStart := (-1) ~ lineName "design")
+          (gridRowStart := (-1) ~ LineName "design")
 
       "grid-row-start:span 5" `isRenderedFrom` (gridRowStart := span ~ 5)
 
       "grid-row-start:span robot"
         `isRenderedFrom`
-          (gridRowStart := span ~ lineName "robot")
+          (gridRowStart := span ~ LineName "robot")
 
       "grid-row-start:span 3 apple"
         `isRenderedFrom`
-          (gridRowStart := span ~ 3 ~ lineName "apple")
+          (gridRowStart := span ~ 3 ~ LineName "apple")
 
     describe "grid-column-start property" do
 
@@ -794,23 +794,23 @@ spec = do
 
       "grid-column-start:pilot"
         `isRenderedFrom`
-          (gridColumnStart := lineName "pilot")
+          (gridColumnStart := LineName "pilot")
 
       "grid-column-start:6" `isRenderedFrom` (gridColumnStart := 6)
 
       "grid-column-start:5 pattern"
         `isRenderedFrom`
-          (gridColumnStart := 5 ~ lineName "pattern")
+          (gridColumnStart := 5 ~ LineName "pattern")
 
       "grid-column-start:span 8" `isRenderedFrom` (gridColumnStart := span ~ 8)
 
       "grid-column-start:span confident"
         `isRenderedFrom`
-          (gridColumnStart := span ~ lineName "confident")
+          (gridColumnStart := span ~ LineName "confident")
 
       "grid-column-start:span 2 around-noise"
         `isRenderedFrom`
-          (gridColumnStart := span ~ 2 ~ lineName "around-noise")
+          (gridColumnStart := span ~ 2 ~ LineName "around-noise")
 
     describe "grid-row-end property" do
 
@@ -822,21 +822,21 @@ spec = do
 
       "grid-row-end:auto" `isRenderedFrom` (gridRowEnd := auto)
 
-      "grid-row-end:minute" `isRenderedFrom` (gridRowEnd := lineName "minute")
+      "grid-row-end:minute" `isRenderedFrom` (gridRowEnd := LineName "minute")
 
       "grid-row-end:-5" `isRenderedFrom` (gridRowEnd := (-5))
 
-      "grid-row-end:8 this" `isRenderedFrom` (gridRowEnd := 8 ~ lineName "this")
+      "grid-row-end:8 this" `isRenderedFrom` (gridRowEnd := 8 ~ LineName "this")
 
       "grid-row-end:span down"
         `isRenderedFrom`
-          (gridRowEnd := span ~ lineName "down")
+          (gridRowEnd := span ~ LineName "down")
 
       "grid-row-end:span 4" `isRenderedFrom` (gridRowEnd := span ~ 4)
 
       "grid-row-end:span 4 plate"
         `isRenderedFrom`
-          (gridRowEnd := span ~ 4 ~ lineName "plate")
+          (gridRowEnd := span ~ 4 ~ LineName "plate")
 
     describe "grid-column-end property" do
 
@@ -848,20 +848,20 @@ spec = do
 
       "grid-column-end:auto" `isRenderedFrom` (gridColumnEnd := auto)
 
-      "grid-column-end:book" `isRenderedFrom` (gridColumnEnd := lineName "book")
+      "grid-column-end:book" `isRenderedFrom` (gridColumnEnd := LineName "book")
 
       "grid-column-end:25" `isRenderedFrom` (gridColumnEnd := 25)
 
       "grid-column-end:4 school"
         `isRenderedFrom`
-          (gridColumnEnd := 4 ~ lineName "school")
+          (gridColumnEnd := 4 ~ LineName "school")
 
       "grid-column-end:span waterfall"
         `isRenderedFrom`
-          (gridColumnEnd := span ~ lineName "waterfall")
+          (gridColumnEnd := span ~ LineName "waterfall")
 
       "grid-column-end:span 9" `isRenderedFrom` (gridColumnEnd := span ~ 9)
 
       "grid-column-end:span 2 paddle"
         `isRenderedFrom`
-          (gridColumnEnd := span ~ 2 ~ lineName "paddle")
+          (gridColumnEnd := span ~ 2 ~ LineName "paddle")


### PR DESCRIPTION
### Description

This change exposes the `LineName` data constructor while deprecating the `lineName` function.

### Design considerations

This follows #34 in dropping the constructor function in favor of a data constructor.

### Future plans

N/A

### References

See #34 for reasoning.

### Code change checklist

- [x] Any new or updated functionality includes corresponding unit test coverage.
- [x] I have verified code formatting, run the unit tests, and checked for any changes in the examples.
- [x] I have added an entry to the _Unreleased_ section of the CHANGELOG.
